### PR TITLE
fixing problem when adding nodes to existing graph that was loaded from file

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -685,7 +685,9 @@ LGraph.prototype.add = function(node, skip_compute_order)
 
 	//give him an id
 	if(node.id == null || node.id == -1)
-		node.id = this.last_node_id++;
+		node.id = ++this.last_node_id;
+	else if (this.last_node_id < node.id)
+		this.last_node_id = node.id;
 
 	node.graph = this;
 


### PR DESCRIPTION
Hey, 

I discovered that the litegraph engine showed strange behaviors in the following scenario:

Adding a new node to a graph that was loaded from file caused the links between some nodes to rearrange.

I found out that the last_node_id value was not updated when a graph was loaded from file. So the manually added node had the id 0 which already existed in the graph.

My fix tries to solve this issue. Hope this helps.

Cheers