### PR TITLE
fix to prevent contextmenu from closing

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -5883,6 +5883,7 @@ ContextMenu.prototype.addItem = function( name, value, options )
 
 ContextMenu.prototype.close = function(e, ignore_parent_menu)
 {
+	if( e.which != 0 ) return // need for chromebooks
 	if(this.root.parentNode)
 		this.root.parentNode.removeChild( this.root );
 	if(this.parentMenu && !ignore_parent_menu)

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -5883,7 +5883,7 @@ ContextMenu.prototype.addItem = function( name, value, options )
 
 ContextMenu.prototype.close = function(e, ignore_parent_menu)
 {
-	if( e.which != 0 ) return // need for chromebooks
+	if( e.which == 0 ) return // need for chromebooks
 	if(this.root.parentNode)
 		this.root.parentNode.removeChild( this.root );
 	if(this.parentMenu && !ignore_parent_menu)


### PR DESCRIPTION
this fix prevents weird contextmenu behavior on a chromebook.
Might have to do with touch(pad).