### PR TITLE
contextmenu fix for chromebook

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -5883,6 +5883,7 @@ ContextMenu.prototype.addItem = function( name, value, options )
 
 ContextMenu.prototype.close = function(e, ignore_parent_menu)
 {
+	if( e != undefined && e.which == 0 ) return
 	if(this.root.parentNode)
 		this.root.parentNode.removeChild( this.root );
 	if(this.parentMenu && !ignore_parent_menu)


### PR DESCRIPTION
otherwise contextmenu closes before user can select an item (probably has to do with touch(pad))