### PR TITLE
Correct use of last_link_id

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -3396,7 +3396,7 @@
 
         if (LiteGraph.isValidConnection(output.type, input.type)) {
             link_info = new LLink(
-                this.graph.last_link_id++,
+                ++this.graph.last_link_id,
                 input.type,
                 this.id,
                 slot,


### PR DESCRIPTION
Before this change, `last_link_id` is used as `next_link_id`

Cause ui issue when i use links length as `last_link_id`.