### PR TITLE
Resolve "'LGraph' is not defined" issue

### DIFF
--- a/src/nodes/base.js
+++ b/src/nodes/base.js
@@ -26,7 +26,7 @@
         this.enabled = true;
 
         //create inner graph
-        this.subgraph = new LGraph();
+        this.subgraph = new LiteGraph.LGraph();
         this.subgraph._subgraph_node = this;
         this.subgraph._is_subgraph = true;
 


### PR DESCRIPTION
Resolve Unable to use SubGraph node with webpack.

* Error message
``` "ReferenceError: 'LGraph' is not defined at Subgraph ```