### PR TITLE
Websocket node bugfixes

### DIFF
--- a/src/nodes/network.js
+++ b/src/nodes/network.js
@@ -86,7 +86,7 @@
         this._ws.onmessage = function(e) {
             that.boxcolor = "#AFA";
             var data = JSON.parse(e.data);
-            if (data.room && data.room != this.properties.room) {
+            if (data.room && data.room != that.properties.room) {
                 return;
             }
             if (e.data.type == 1) {

--- a/src/nodes/network.js
+++ b/src/nodes/network.js
@@ -89,7 +89,7 @@
             if (data.room && data.room != that.properties.room) {
                 return;
             }
-            if (e.data.type == 1) {
+            if (data.type == 1) {
                 if (
                     data.data.object_class &&
                     LiteGraph[data.data.object_class]
@@ -105,7 +105,7 @@
                     that.triggerSlot(0, data.data);
                 }
             } else {
-                that._last_received_data[e.data.channel || 0] = data.data;
+                that._last_received_data[data.channel || 0] = data.data;
             }
         };
         this._ws.onerror = function(e) {


### PR DESCRIPTION
Hello, love the library :)

I was trying to use the websocket node and hitting some problems:

- `this` was used instead of `that`, so the room name could never be properly checked
- JSON string was being parsed, but then when attempting to actually read attributes from it, the original raw data was used instead

With these two patches, I am able to use the websocket node as I expect.

Apologies if I have something wrong here!