### PR TITLE
resolve "TypeError: Cannot redefine property: shape" issue

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -159,7 +159,8 @@
 					get: function(v) {
 						return this._shape;
 					},
-					enumerable: true
+					enumerable: true,
+					configurable: true
 				});
 			}
 


### PR DESCRIPTION
When same node registered twice. It gives error.
ex:
LiteGraph.registerNodeType("basic/test", MyAddNode);
LiteGraph.registerNodeType("basic/test", MyAddNode);

To redefine an object property with "Object.defineProperty" method, configurable property should be set on true ( default is false)
ex : Object.defineProperty( '...' , '...' , {configurable: true})