### PR TITLE
Documentation mismatch

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -1477,7 +1477,7 @@
 
     /**
      * Tell this graph it has a global graph input of this type
-     * @method addGlobalInput
+     * @method addInput
      * @param {String} name
      * @param {String} type
      * @param {*} value [optional]
@@ -1503,7 +1503,7 @@
 
     /**
      * Assign a data to the global graph input
-     * @method setGlobalInputData
+     * @method setInputData
      * @param {String} name
      * @param {*} data
      */


### PR DESCRIPTION
Some method names didn't match the actual method names, rendering the automatically generated documentation misleading