### PR TITLE
Updated arrange method to support vertical layout of nodes

### DIFF
--- a/src/litegraph.d.ts
+++ b/src/litegraph.d.ts
@@ -412,7 +412,7 @@ export declare class LGraph {
     /**
      * Positions every node in a more readable manner
      */
-    arrange(margin?: number): void;
+    arrange(margin?: number,layout?: string): void;
     /**
      * Returns the amount of time the graph has been running in milliseconds
      * @return number of milliseconds the graph has been running

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -80,6 +80,7 @@
         NO_TITLE: 1,
         TRANSPARENT_TITLE: 2,
         AUTOHIDE_TITLE: 3,
+        VERTICAL_LAYOUT: "vertical", // arrange nodes vertically
 
         proxy: null, //used to redirect calls
         node_images_path: "",
@@ -1146,7 +1147,7 @@
      * Positions every node in a more readable manner
      * @method arrange
      */
-    LGraph.prototype.arrange = function(margin) {
+    LGraph.prototype.arrange = function (margin, layout) {
         margin = margin || 100;
 
         var nodes = this.computeExecutionOrder(false, true);
@@ -1171,12 +1172,14 @@
             var y = margin + LiteGraph.NODE_TITLE_HEIGHT;
             for (var j = 0; j < column.length; ++j) {
                 var node = column[j];
-                node.pos[0] = x;
-                node.pos[1] = y;
-                if (node.size[0] > max_size) {
-                    max_size = node.size[0];
+                node.pos[0] = (layout == LiteGraph.VERTICAL_LAYOUT) ? y : x;
+                node.pos[1] = (layout == LiteGraph.VERTICAL_LAYOUT) ? x : y;
+                max_size_index = (layout == LiteGraph.VERTICAL_LAYOUT) ? 1 : 0;
+                if (node.size[max_size_index] > max_size) {
+                    max_size = node.size[max_size_index];
                 }
-                y += node.size[1] + margin + LiteGraph.NODE_TITLE_HEIGHT;
+                node_size_index = (layout == LiteGraph.VERTICAL_LAYOUT) ? 0 : 1;
+                y += node.size[node_size_index] + margin + LiteGraph.NODE_TITLE_HEIGHT
             }
             x += max_size + margin;
         }

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -1179,7 +1179,7 @@
                     max_size = node.size[max_size_index];
                 }
                 node_size_index = (layout == LiteGraph.VERTICAL_LAYOUT) ? 0 : 1;
-                y += node.size[node_size_index] + margin + LiteGraph.NODE_TITLE_HEIGHT
+                y += node.size[node_size_index] + margin + LiteGraph.NODE_TITLE_HEIGHT;
             }
             x += max_size + margin;
         }


### PR DESCRIPTION
Hi  @jagenjo ,
We have requirement to layout network graph vertically instead horizontally  as `arrange` method of `litegraph` does ,so 
In this PR i updated `arrange` method of `litegraph` to layout nodes vertically.

Usages -
const graph = new LGraph()
1. For Horizontal Layout use as before **graph.arrange()**

<img width="975" alt="Screenshot 2020-07-28 at 9 47 11 AM" src="https://user-images.githubusercontent.com/13414728/88645032-490c8e00-d0e1-11ea-8923-e13989df1f87.png">

2. For vertical layout use  **graph.arrange(margin,LiteGraph.VERTICAL_LAYOUT);**
<img width="824" alt="Screenshot 2020-07-28 at 9 46 50 AM" src="https://user-images.githubusercontent.com/13414728/88645263-8ec95680-d0e1-11ea-855a-a31d8a695b32.png">




