### PR TITLE
Add ability to automatically sort node types / categories in the context menu

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -96,6 +96,7 @@
 		Globals: {}, //used to store vars between graphs
 
         searchbox_extras: {}, //used to add extra features to the search box
+        auto_sort_node_types: false, // If set to true, will automatically sort node types / categories in the context menus
 
         /**
          * Register a node class so it can be listed when the user wants to create a new one
@@ -416,7 +417,7 @@
                 }
             }
 
-            return r;
+            return this.auto_sort_node_types ? r.sort() : r;
         },
 
         /**
@@ -440,7 +441,7 @@
             for (var i in categories) {
                 result.push(i);
             }
-            return result;
+            return this.auto_sort_node_types ? result.sort() : result;
         },
 
         //debug purposes: reloads all the js scripts that matches a wildcard


### PR DESCRIPTION
**Purpose of change**
In a project I'm working on, I've been removing node types that aren't required by the project, but when doing this, it resulted in some unexpected sorting issues once the `registered_node_types` object begins to have items removed from it.

To get around this, I added sorting to ensure the node types / categories are always displayed in order to maintain consistency when node types are added or removed regardless of the order in `registered_node_types`

**How to use new feature**
To enable this functionality, a user needs to set `LiteGraph.auto_sort_node_types` to true, and then all subsequent context menus that are opened will have a sorted menu.

By default, the newly added property will be `false` (meaning the feature will be disabled by default) to ensure the default functionality of the context menu does not unexpectedly change for existing projects.

**Examples**
When `LiteGraph.auto_sort_node_types` is `false`:
![image](https://user-images.githubusercontent.com/49003204/94840739-cd94c900-0410-11eb-9a11-d3827970d8dc.png)

When `LiteGraph.auto_sort_node_types` is `true`:
![image](https://user-images.githubusercontent.com/49003204/94840772-deddd580-0410-11eb-80ad-211fc2a1ebee.png)
