### PR TITLE
Add option to stylise property names + a bug fix in the property editor

### DIFF
--- a/build/litegraph.min.js
+++ b/build/litegraph.min.js
@@ -288,7 +288,13 @@ $jscomp.polyfill("Object.values", function(x) {
   }
   var f = x.LiteGraph = {VERSION:0.4, CANVAS_GRID_SIZE:10, NODE_TITLE_HEIGHT:30, NODE_TITLE_TEXT_Y:20, NODE_SLOT_HEIGHT:20, NODE_WIDGET_HEIGHT:20, NODE_WIDTH:140, NODE_MIN_WIDTH:50, NODE_COLLAPSED_RADIUS:10, NODE_COLLAPSED_WIDTH:80, NODE_TITLE_COLOR:"#999", NODE_SELECTED_TITLE_COLOR:"#FFF", NODE_TEXT_SIZE:14, NODE_TEXT_COLOR:"#AAA", NODE_SUBTEXT_SIZE:12, NODE_DEFAULT_COLOR:"#333", NODE_DEFAULT_BGCOLOR:"#353535", NODE_DEFAULT_BOXCOLOR:"#666", NODE_DEFAULT_SHAPE:"box", NODE_BOX_OUTLINE_COLOR:"#FFF", 
   DEFAULT_SHADOW_COLOR:"rgba(0,0,0,0.5)", DEFAULT_GROUP_FONT:24, WIDGET_BGCOLOR:"#222", WIDGET_OUTLINE_COLOR:"#666", WIDGET_TEXT_COLOR:"#DDD", WIDGET_SECONDARY_TEXT_COLOR:"#999", LINK_COLOR:"#9A9", EVENT_LINK_COLOR:"#A86", CONNECTING_LINK_COLOR:"#AFA", MAX_NUMBER_OF_NODES:1000, DEFAULT_POSITION:[100, 100], VALID_SHAPES:["default", "box", "round", "card"], BOX_SHAPE:1, ROUND_SHAPE:2, CIRCLE_SHAPE:3, CARD_SHAPE:4, ARROW_SHAPE:5, INPUT:1, OUTPUT:2, EVENT:-1, ACTION:-1, ALWAYS:0, ON_EVENT:1, NEVER:2, 
-  ON_TRIGGER:3, UP:1, DOWN:2, LEFT:3, RIGHT:4, CENTER:5, STRAIGHT_LINK:0, LINEAR_LINK:1, SPLINE_LINK:2, NORMAL_TITLE:0, NO_TITLE:1, TRANSPARENT_TITLE:2, AUTOHIDE_TITLE:3, proxy:null, node_images_path:"", debug:!1, catch_exceptions:!0, throw_errors:!0, allow_scripts:!1, registered_node_types:{}, node_types_by_file_extension:{}, Nodes:{}, Globals:{}, searchbox_extras:{}, registerNodeType:function(a, b) {
+  ON_TRIGGER:3, UP:1, DOWN:2, LEFT:3, RIGHT:4, CENTER:5, STRAIGHT_LINK:0, LINEAR_LINK:1, SPLINE_LINK:2, NORMAL_TITLE:0, NO_TITLE:1, TRANSPARENT_TITLE:2, AUTOHIDE_TITLE:3, proxy:null, node_images_path:"", debug:!1, catch_exceptions:!0, throw_errors:!0, allow_scripts:!1, registered_node_types:{}, node_types_by_file_extension:{}, Nodes:{}, Globals:{}, searchbox_extras:{}, auto_sort_node_types:!1, stylise_property_names:!1, stylisePropertyName:function(a) {
+    a = a.replace(/([a-z\d])([A-Z])/g, "$1 $2").replace(/(.+?)_(.+?)/g, "$1 $2").split(" ");
+    for (var b = 0; b < a.length; b++) {
+      a[b] = a[b][0].toUpperCase() + a[b].substr(1);
+    }
+    return a.join(" ");
+  }, registerNodeType:function(a, b) {
     if (!b.prototype) {
       throw "Cannot register a simple object, it must be a class with a prototype";
     }
@@ -423,7 +429,7 @@ $jscomp.polyfill("Object.values", function(x) {
       var g = this.registered_node_types[e];
       g.filter == b && ("" == a ? null == g.category && d.push(g) : g.category == a && d.push(g));
     }
-    return d;
+    return this.auto_sort_node_types ? d.sort() : d;
   }, getNodeTypesCategories:function(a) {
     var b = {"":1}, d;
     for (d in this.registered_node_types) {
@@ -434,7 +440,7 @@ $jscomp.polyfill("Object.values", function(x) {
     for (d in b) {
       a.push(d);
     }
-    return a;
+    return this.auto_sort_node_types ? a.sort() : a;
   }, reloadNodes:function(a) {
     for (var b = document.getElementsByTagName("script"), d = [], e = 0; e < b.length; e++) {
       d.push(b[e]);
@@ -4048,7 +4054,9 @@ $jscomp.polyfill("Object.values", function(x) {
           a = m.getPropertyPrintableValue(a, n.values);
         }
         a = m.decodeHTML(a);
-        k.push({content:"<span class='property_name'>" + p + "</span><span class='property_value'>" + a + "</span>", value:p});
+        n = p;
+        f.stylise_property_names && (n = f.stylisePropertyName(p));
+        k.push({content:"<span class='property_name'>" + n + "</span><span class='property_value'>" + a + "</span>", value:p});
       }
       if (k.length) {
         return new f.ContextMenu(k, {event:d, callback:function(a, b, d, e) {
@@ -4329,12 +4337,12 @@ $jscomp.polyfill("Object.values", function(x) {
   };
   m.prototype.showEditPropertyValue = function(a, b, d) {
     function e() {
-      g(l.value);
+      g(m.value);
     }
     function g(g) {
       c && c.values && c.values.constructor === Object && void 0 != c.values[g] && (g = c.values[g]);
       "number" == typeof a.properties[b] && (g = Number(g));
-      if ("array" == f || "object" == f) {
+      if ("array" == k || "object" == k) {
         g = JSON.parse(g);
       }
       a.properties[b] = g;
@@ -4345,55 +4353,57 @@ $jscomp.polyfill("Object.values", function(x) {
       if (d.onclose) {
         d.onclose();
       }
-      h.close();
+      l.close();
       a.setDirtyCanvas(!0, !0);
     }
     if (a && void 0 !== a.properties[b]) {
       d = d || {};
-      var c = a.getPropertyInfo(b), f = c.type, k = "";
-      if ("string" == f || "number" == f || "array" == f || "object" == f) {
-        k = "<input autofocus type='text' class='value'/>";
+      var c = a.getPropertyInfo(b), k = c.type, p = "";
+      if ("string" == k || "number" == k || "array" == k || "object" == k) {
+        p = "<input autofocus type='text' class='value'/>";
       } else {
-        if ("enum" != f && "combo" != f || !c.values) {
-          if ("boolean" == f) {
-            k = "<input autofocus type='checkbox' class='value' " + (a.properties[b] ? "checked" : "") + "/>";
+        if ("enum" != k && "combo" != k || !c.values) {
+          if ("boolean" == k) {
+            p = "<input autofocus type='checkbox' class='value' " + (a.properties[b] ? "checked" : "") + "/>";
           } else {
-            console.warn("unknown type: " + f);
+            console.warn("unknown type: " + k);
             return;
           }
         } else {
-          k = "<select autofocus type='text' class='value'>";
-          for (var p in c.values) {
-            var n = p;
-            c.values.constructor === Array && (n = c.values[p]);
-            k += "<option value='" + n + "' " + (n == a.properties[b] ? "selected" : "") + ">" + c.values[p] + "</option>";
+          p = "<select autofocus type='text' class='value'>";
+          for (var n in c.values) {
+            var h = n;
+            c.values.constructor === Array && (h = c.values[n]);
+            p += "<option value='" + h + "' " + (h == a.properties[b] ? "selected" : "") + ">" + c.values[n] + "</option>";
           }
-          k += "</select>";
+          p += "</select>";
         }
       }
-      var h = this.createDialog("<span class='name'>" + b + "</span>" + k + "<button>OK</button>", d);
-      if ("enum" != f && "combo" != f || !c.values) {
-        if ("boolean" == f) {
-          (l = h.querySelector("input")) && l.addEventListener("click", function(a) {
-            g(!!l.checked);
+      n = b;
+      f.stylise_property_names && (n = f.stylisePropertyName(b));
+      var l = this.createDialog("<span class='name'>" + n + "</span>" + p + "<button>OK</button>", d);
+      if ("enum" != k && "combo" != k || !c.values) {
+        if ("boolean" == k) {
+          (m = l.querySelector("input")) && m.addEventListener("click", function(a) {
+            g(!!m.checked);
           });
         } else {
-          if (l = h.querySelector("input")) {
-            l.addEventListener("blur", function(a) {
+          if (m = l.querySelector("input")) {
+            m.addEventListener("blur", function(a) {
               this.focus();
-            }), n = void 0 !== a.properties[b] ? a.properties[b] : "", n = JSON.stringify(n), l.value = n, l.addEventListener("keydown", function(a) {
+            }), h = void 0 !== a.properties[b] ? a.properties[b] : "", h.constructor !== String && (h = JSON.stringify(h)), m.value = h, m.addEventListener("keydown", function(a) {
               13 == a.keyCode && (e(), a.preventDefault(), a.stopPropagation());
             });
           }
         }
       } else {
-        var l = h.querySelector("select");
-        l.addEventListener("change", function(a) {
+        var m = l.querySelector("select");
+        m.addEventListener("change", function(a) {
           g(a.target.value);
         });
       }
-      h.querySelector("button").addEventListener("click", e);
-      return h;
+      l.querySelector("button").addEventListener("click", e);
+      return l;
     }
   };
   m.prototype.createDialog = function(a, b) {
@@ -9335,15 +9345,15 @@ $jscomp.polyfill("Object.values", function(x) {
     this.setup(c.data);
   };
   c.prototype.setup = function(f) {
-    var n = f;
-    f.constructor === Object && (n = f.data);
-    this.data.set(n);
-    this.status = f = n[0];
-    n = f & 240;
-    this.cmd = 240 <= f ? f : n;
+    var p = f;
+    f.constructor === Object && (p = f.data);
+    this.data.set(p);
+    this.status = f = p[0];
+    p = f & 240;
+    this.cmd = 240 <= f ? f : p;
     this.cmd == c.NOTEON && 0 == this.velocity && (this.cmd = c.NOTEOFF);
     this.cmd_str = c.commands[this.cmd] || "";
-    if (n >= c.NOTEON || n <= c.NOTEOFF) {
+    if (p >= c.NOTEON || p <= c.NOTEOFF) {
       this.channel = f & 15;
     }
   };
@@ -9424,18 +9434,18 @@ $jscomp.polyfill("Object.values", function(x) {
         return Number(f);
     }
   };
-  c.toNoteString = function(f, n) {
+  c.toNoteString = function(f, h) {
     f = Math.round(f);
     var k = Math.floor((f - 24) / 12 + 1);
     f = (f - 21) % 12;
     0 > f && (f = 12 + f);
-    return c.notes[f] + (n ? "" : k);
+    return c.notes[f] + (h ? "" : k);
   };
   c.NoteStringToPitch = function(f) {
     f = f.toUpperCase();
-    var n = f[0], k = 4;
-    "#" == f[1] ? (n += "#", 2 < f.length && (k = Number(f[2]))) : 1 < f.length && (k = Number(f[1]));
-    f = c.note_to_index[n];
+    var h = f[0], k = 4;
+    "#" == f[1] ? (h += "#", 2 < f.length && (k = Number(f[2]))) : 1 < f.length && (k = Number(f[1]));
+    f = c.note_to_index[h];
     return null == f ? null : 12 * (k - 1) + f + 21;
   };
   c.prototype.toString = function() {

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -10110,8 +10110,12 @@ LGraphNode.prototype.executeAction = function(action)
                 input.addEventListener("blur", function(e) {
                     this.focus();
                 });
-				var v = node.properties[property] !== undefined ? node.properties[property] : "";
-				v = JSON.stringify(v);
+
+                var v = node.properties[property] !== undefined ? node.properties[property] : "";
+				if (v.constructor !== String) {
+                    v = JSON.stringify(v);
+                }
+
                 input.value = v;
                 input.addEventListener("keydown", function(e) {
                     if (e.keyCode != 13) {

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -97,6 +97,27 @@
 
         searchbox_extras: {}, //used to add extra features to the search box
         auto_sort_node_types: false, // If set to true, will automatically sort node types / categories in the context menus
+        stylise_property_names: false, // If set to true, will display property names like "firstName" and "first_name" as "First Name"
+
+        /**
+         * Stylise a property name that uses camel casing or underscores
+         * @method stylisePropertyName
+         * @param {String} name the property name to stylise
+         * @return {String} the property name capitalised and separated by spaces
+         */
+
+        stylisePropertyName: function(name) {
+            var prettyName = name
+                .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+                .replace(/(.+?)_(.+?)/g, '$1 $2')
+                .split(' ');
+
+            for (var i = 0; i < prettyName.length; i++) {
+                prettyName[i] = prettyName[i][0].toUpperCase() + prettyName[i].substr(1);
+            }
+
+            return prettyName.join(' ');
+        },
 
         /**
          * Register a node class so it can be listed when the user wants to create a new one
@@ -9450,10 +9471,16 @@ LGraphNode.prototype.executeAction = function(action)
 
             //value could contain invalid html characters, clean that
             value = LGraphCanvas.decodeHTML(value);
+
+            var displayName = i;
+            if (LiteGraph.stylise_property_names) {
+                displayName = LiteGraph.stylisePropertyName(i);
+            }
+
             entries.push({
                 content:
                     "<span class='property_name'>" +
-                    i +
+                    displayName +
                     "</span>" +
                     "<span class='property_value'>" +
                     value +
@@ -10049,9 +10076,14 @@ LGraphNode.prototype.executeAction = function(action)
             return;
         }
 
+        var displayName = property;
+        if (LiteGraph.stylise_property_names) {
+            displayName = LiteGraph.stylisePropertyName(property);
+        }
+
         var dialog = this.createDialog(
             "<span class='name'>" +
-                property +
+                displayName +
                 "</span>" +
                 input_html +
                 "<button>OK</button>",


### PR DESCRIPTION
This PR contains two changes
- A fix to a bug causing subsequent changes to a string property to run into a serialisation issue
- A new feature to allow for property names to be automatically stylised in the property editor

## Change 1: The Bug
The bug can be replicated by:

- Add a node that has a string property that can be changed
- Right click the node and go to the properties
- When the editor opens, click "OK"
- Repeat the first 3 steps several times to see the quotations that are added be re-added and encoded several times

See screenshots below of this happening:

![Screenshot from 2020-10-05 16-27-02](https://user-images.githubusercontent.com/49003204/95102746-ac431e00-072b-11eb-8e46-568b73a22e12.png)
![Screenshot from 2020-10-05 16-27-12](https://user-images.githubusercontent.com/49003204/95102749-acdbb480-072b-11eb-9899-f67f4efd1f3b.png)
![Screenshot from 2020-10-05 16-27-21](https://user-images.githubusercontent.com/49003204/95102750-acdbb480-072b-11eb-8a3c-0a6c65092771.png)

**The Fix**
The fix to this was to not use the `JSON.stringify` method when the property value is a string. If a string is passed to `JSON.stringify`, it will wrap it in double quotes. Instead, it will now only be parsed as JSON when it is **not** a string. As a result, when opening the property editor now, no double quotes will be added:

![Screenshot from 2020-10-05 16-47-09](https://user-images.githubusercontent.com/49003204/95102967-f1675000-072b-11eb-800e-2b727bbcc908.png)

## Change 2: Auto Stylising of Property Names in Editor
When using the context menu to reach the properties editor, it displays the names of the properties as they are stored in code, both in the context menu and the editor, as can be seen below for the `argCount` property:

![image](https://user-images.githubusercontent.com/49003204/95103185-3ab79f80-072c-11eb-938f-da1ff6b328ca.png)
![image](https://user-images.githubusercontent.com/49003204/95103209-41dead80-072c-11eb-9a9b-a0d9f72b1b08.png)

In the application I have been working on, this is a bit problematic, so I have added an option (which is disabled by default), that will automatically parse property names that are stored in camel case, or separated by underscore and stylise them like this:

![image](https://user-images.githubusercontent.com/49003204/95103388-718db580-072c-11eb-8afa-f5b02e012fe7.png)
![image](https://user-images.githubusercontent.com/49003204/95103402-76eb0000-072c-11eb-8600-0cbc1c9799df.png)

To enable this functionality, users can set `LiteGraph.stylise_property_names` to `true`. It is able to handle cases where a mixed set of styles are used too. For example, if the property name was `a_mixedStyleType` it would display it as `A Mixed Style Type`

**Note:** the build in this PR includes the changes from PR #177 - so if you merge this one, you could close the other PR. 

Also, if you are happy for this  to get merged in, would you mind adding the `hacktoberfest-accepted` label to the PR so it can count towards my contributions for [Hacktoberfest](https://hacktoberfest.digitalocean.com/)? :smiley: 
