### PR TITLE
Add option to stylise property names

### DIFF
--- a/build/litegraph.js
+++ b/build/litegraph.js
@@ -9453,7 +9453,7 @@ LGraphNode.prototype.executeAction = function(action)
             entries.push({
                 content:
                     "<span class='property_name'>" +
-                    i +
+                    (info.descriptor ? info.descriptor : i) +
                     "</span>" +
                     "<span class='property_value'>" +
                     value +
@@ -10051,7 +10051,7 @@ LGraphNode.prototype.executeAction = function(action)
 
         var dialog = this.createDialog(
             "<span class='name'>" +
-                property +
+                (info.descriptor ? info.descriptor : property) +
                 "</span>" +
                 input_html +
                 "<button>OK</button>",

--- a/build/litegraph.min.js
+++ b/build/litegraph.min.js
@@ -4048,7 +4048,7 @@ $jscomp.polyfill("Object.values", function(x) {
           a = m.getPropertyPrintableValue(a, n.values);
         }
         a = m.decodeHTML(a);
-        k.push({content:"<span class='property_name'>" + p + "</span><span class='property_value'>" + a + "</span>", value:p});
+        k.push({content:"<span class='property_name'>" + (n.descriptor ? n.descriptor : p) + "</span><span class='property_value'>" + a + "</span>", value:p});
       }
       if (k.length) {
         return new f.ContextMenu(k, {event:d, callback:function(a, b, d, e) {
@@ -4371,7 +4371,7 @@ $jscomp.polyfill("Object.values", function(x) {
           k += "</select>";
         }
       }
-      var h = this.createDialog("<span class='name'>" + b + "</span>" + k + "<button>OK</button>", d);
+      var h = this.createDialog("<span class='name'>" + (c.descriptor ? c.descriptor : b) + "</span>" + k + "<button>OK</button>", d);
       if ("enum" != f && "combo" != f || !c.values) {
         if ("boolean" == f) {
           (l = h.querySelector("input")) && l.addEventListener("click", function(a) {
@@ -5295,18 +5295,18 @@ $jscomp.polyfill("Object.values", function(x) {
     for (d = 0; d < a.length; ++d) {
       g = a[d];
       if (g.inputs) {
-        for (var e = 0; e < g.inputs.length; ++e) {
-          var c = g.inputs[e];
-          if (c && c.link) {
-            var f = g.graph.links[c.link];
-            f && (b[f.origin_id] || this.subgraph.addInput(c.name, f.type));
+        for (var c = 0; c < g.inputs.length; ++c) {
+          var e = g.inputs[c];
+          if (e && e.link) {
+            var f = g.graph.links[e.link];
+            f && (b[f.origin_id] || this.subgraph.addInput(e.name, f.type));
           }
         }
       }
       if (g.outputs) {
-        for (e = 0; e < g.outputs.length; ++e) {
-          if ((c = g.outputs[e]) && c.links && c.links.length) {
-            for (var k = 0; k < c.links.length && (!(f = g.graph.links[c.links[k]]) || b[f.target_id]); ++k) {
+        for (c = 0; c < g.outputs.length; ++c) {
+          if ((e = g.outputs[c]) && e.links && e.links.length) {
+            for (var k = 0; k < e.links.length && (!(f = g.graph.links[e.links[k]]) || b[f.target_id]); ++k) {
             }
           }
         }
@@ -5568,13 +5568,13 @@ $jscomp.polyfill("Object.values", function(x) {
   t.prototype.onExecute = function() {
     var a = this.getInputData(0), b = this.getInputData(1), d = this._result;
     if (a) {
-      for (var c in a) {
-        d[c] = a[c];
+      for (var e in a) {
+        d[e] = a[e];
       }
     }
     if (b) {
-      for (c in b) {
-        d[c] = b[c];
+      for (e in b) {
+        d[e] = b[e];
       }
     }
     this.setOutputData(0, d);
@@ -5714,8 +5714,8 @@ $jscomp.polyfill("Object.values", function(x) {
     if (256 < a.length) {
       console.warn("Script too long, max 256 chars");
     } else {
-      for (var b = a.toLowerCase(), d = "script body document eval nodescript function".split(" "), c = 0; c < d.length; ++c) {
-        if (-1 != b.indexOf(d[c])) {
+      for (var b = a.toLowerCase(), d = "script body document eval nodescript function".split(" "), e = 0; e < d.length; ++e) {
+        if (-1 != b.indexOf(d[e])) {
           console.warn("invalid script");
           return;
         }
@@ -10347,8 +10347,8 @@ $jscomp.polyfill("Object.values", function(x) {
     this.trigger("start");
     b.onended = function() {
       a.trigger("ended");
-      var c = a._audionodes.indexOf(b);
-      -1 != c && a._audionodes.splice(c, 1);
+      var d = a._audionodes.indexOf(b);
+      -1 != d && a._audionodes.splice(d, 1);
     };
     b.started || (b.started = !0, b.start());
     return b;

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -9453,7 +9453,7 @@ LGraphNode.prototype.executeAction = function(action)
             entries.push({
                 content:
                     "<span class='property_name'>" +
-                    i +
+                    (info.descriptor ? info.descriptor : i) +
                     "</span>" +
                     "<span class='property_value'>" +
                     value +
@@ -10051,7 +10051,7 @@ LGraphNode.prototype.executeAction = function(action)
 
         var dialog = this.createDialog(
             "<span class='name'>" +
-                property +
+                (info.descriptor ? info.descriptor : property) +
                 "</span>" +
                 input_html +
                 "<button>OK</button>",


### PR DESCRIPTION
The changes in this PR allow users to specify a descriptor for the properties so the property name can be displayed in a more human readable format (as per discussion on PR #178)

To specify a custom display name for a property in the context menu / editor dialog, user's can specify the descriptor info like so:

```javascript
MyNode['@propertyName'] = { descriptor: 'A More Readable Name' };
```