### PR TITLE
Change property descriptor terminology + bug fix

### DIFF
--- a/build/litegraph.js
+++ b/build/litegraph.js
@@ -9453,7 +9453,7 @@ LGraphNode.prototype.executeAction = function(action)
             entries.push({
                 content:
                     "<span class='property_name'>" +
-                    (info.descriptor ? info.descriptor : i) +
+                    (info.label ? info.label : i) +
                     "</span>" +
                     "<span class='property_value'>" +
                     value +
@@ -10051,7 +10051,7 @@ LGraphNode.prototype.executeAction = function(action)
 
         var dialog = this.createDialog(
             "<span class='name'>" +
-                (info.descriptor ? info.descriptor : property) +
+                (info.label ? info.label : property) +
                 "</span>" +
                 input_html +
                 "<button>OK</button>",

--- a/build/litegraph.js
+++ b/build/litegraph.js
@@ -10078,8 +10078,12 @@ LGraphNode.prototype.executeAction = function(action)
                 input.addEventListener("blur", function(e) {
                     this.focus();
                 });
+
 				var v = node.properties[property] !== undefined ? node.properties[property] : "";
-				v = JSON.stringify(v);
+				if (type !== 'string') {
+                    v = JSON.stringify(v);
+                }
+
                 input.value = v;
                 input.addEventListener("keydown", function(e) {
                     if (e.keyCode != 13) {

--- a/build/litegraph.min.js
+++ b/build/litegraph.min.js
@@ -4048,7 +4048,7 @@ $jscomp.polyfill("Object.values", function(x) {
           a = m.getPropertyPrintableValue(a, n.values);
         }
         a = m.decodeHTML(a);
-        k.push({content:"<span class='property_name'>" + (n.descriptor ? n.descriptor : p) + "</span><span class='property_value'>" + a + "</span>", value:p});
+        k.push({content:"<span class='property_name'>" + (n.label ? n.label : p) + "</span><span class='property_value'>" + a + "</span>", value:p});
       }
       if (k.length) {
         return new f.ContextMenu(k, {event:d, callback:function(a, b, d, e) {
@@ -4371,7 +4371,7 @@ $jscomp.polyfill("Object.values", function(x) {
           k += "</select>";
         }
       }
-      var h = this.createDialog("<span class='name'>" + (c.descriptor ? c.descriptor : b) + "</span>" + k + "<button>OK</button>", d);
+      var h = this.createDialog("<span class='name'>" + (c.label ? c.label : b) + "</span>" + k + "<button>OK</button>", d);
       if ("enum" != f && "combo" != f || !c.values) {
         if ("boolean" == f) {
           (l = h.querySelector("input")) && l.addEventListener("click", function(a) {

--- a/build/litegraph.min.js
+++ b/build/litegraph.min.js
@@ -4381,7 +4381,7 @@ $jscomp.polyfill("Object.values", function(x) {
           if (l = h.querySelector("input")) {
             l.addEventListener("blur", function(a) {
               this.focus();
-            }), n = void 0 !== a.properties[b] ? a.properties[b] : "", n = JSON.stringify(n), l.value = n, l.addEventListener("keydown", function(a) {
+            }), n = void 0 !== a.properties[b] ? a.properties[b] : "", "string" !== f && (n = JSON.stringify(n)), l.value = n, l.addEventListener("keydown", function(a) {
               13 == a.keyCode && (e(), a.preventDefault(), a.stopPropagation());
             });
           }

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -9453,7 +9453,7 @@ LGraphNode.prototype.executeAction = function(action)
             entries.push({
                 content:
                     "<span class='property_name'>" +
-                    (info.descriptor ? info.descriptor : i) +
+                    (info.label ? info.label : i) +
                     "</span>" +
                     "<span class='property_value'>" +
                     value +
@@ -10051,7 +10051,7 @@ LGraphNode.prototype.executeAction = function(action)
 
         var dialog = this.createDialog(
             "<span class='name'>" +
-                (info.descriptor ? info.descriptor : property) +
+                (info.label ? info.label : property) +
                 "</span>" +
                 input_html +
                 "<button>OK</button>",

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -10078,8 +10078,12 @@ LGraphNode.prototype.executeAction = function(action)
                 input.addEventListener("blur", function(e) {
                     this.focus();
                 });
+
 				var v = node.properties[property] !== undefined ? node.properties[property] : "";
-				v = JSON.stringify(v);
+				if (type !== 'string') {
+                    v = JSON.stringify(v);
+                }
+
                 input.value = v;
                 input.addEventListener("keydown", function(e) {
                     if (e.keyCode != 13) {


### PR DESCRIPTION
This changes the descriptor terminology to `labels` as per suggestion in PR #179 

I've also included the fix to the serialisation of string properties as we spoke about in PR #178 

I've done some testing of the bug fix to make sure it doesn't break things like editing arrays, and I was able to both successfully edit arrays, and also edit strings without the serialisation issue:

![image](https://user-images.githubusercontent.com/49003204/95110629-3bedca00-0736-11eb-962a-5fa5bb73257f.png)

Again, if this is OK, would you mind adding the `hacktoberfest-accepted` label to the pull request on GitHub so this can count to [Hacktoberfest](https://hacktoberfest.digitalocean.com/)? Thanks :smiley: 