### PR TITLE
Fix Boundary and collapsed issue

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -3499,7 +3499,7 @@
         out[0] = this.pos[0] - 4;
         out[1] = this.pos[1] - LiteGraph.NODE_TITLE_HEIGHT;
         out[2] = this.size[0] + 4;
-        out[3] = this.size[1] + LiteGraph.NODE_TITLE_HEIGHT;
+        out[3] = this.flags.collapsed ? LiteGraph.NODE_TITLE_HEIGHT : this.size[1] + LiteGraph.NODE_TITLE_HEIGHT;
 
         if (this.onBounding) {
             this.onBounding(out);
@@ -8842,7 +8842,7 @@ LGraphNode.prototype.executeAction = function(action)
 			var widget_width = w.width || width;
 			//outside
 			if ( w != active_widget && 
-				(x < 6 || x > widget_width - 12 || y < w.last_y || y > w.last_y + widget_height) ) 
+				(x < 6 || x > widget_width - 12 || y < w.last_y || y > w.last_y + widget_height || w.last_y === undefined) ) 
 				continue;
 
 			var old_value = w.value;


### PR DESCRIPTION
* **Resolved Issue:** If you collapse a node with a widget after loading the graph, it cannot be expanded.
![Animation2](https://user-images.githubusercontent.com/39144843/118919380-58f6a680-b96f-11eb-908f-6bfce66db696.gif)

* **Resolved Issue:** Compute Collapsed Nodes boundary is incorrect
![Animation](https://user-images.githubusercontent.com/39144843/118919391-5eec8780-b96f-11eb-9671-59525f88ac83.gif)
