### PR TITLE
Separator only drawn when title is drawn

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -7930,7 +7930,7 @@ LGraphNode.prototype.executeAction = function(action)
             ctx.fill();
 
 			//separator
-			if(!node.flags.collapsed)
+			if(!node.flags.collapsed && render_title)
 			{
 				ctx.shadowColor = "transparent";
 				ctx.fillStyle = "rgba(0,0,0,0.2)";


### PR DESCRIPTION
The seperator between node title and node body does not need to be rendered when the node title is not rendered. Otherwise, you have a floating line above your node