### PR TITLE
Optionally leave out drawing title

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -8060,7 +8060,8 @@ LGraphNode.prototype.executeAction = function(action)
             if (!low_quality) {
                 ctx.font = this.title_text_font;
                 var title = String(node.getTitle());
-                if (title) {
+                var draw_title_text = node.constructor.draw_title_text || true;
+                if (title && draw_title_text) {
                     if (selected) {
                         ctx.fillStyle = LiteGraph.NODE_SELECTED_TITLE_COLOR;
                     } else {


### PR DESCRIPTION
This is a feature request... I can fully customize the title with onDrawTitleText, but I cannot find a way to leave out the title for just one specific node. Would be a nice feature to add