### PR TITLE
Fix to only show console warn if debug is enabled

### DIFF
--- a/src/nodes/math3d.js
+++ b/src/nodes/math3d.js
@@ -567,7 +567,7 @@
 
 
     } //glMatrix
-	else
+	else if (LiteGraph.debug)
 		console.warn("No glmatrix found, some Math3D nodes may not work");
 
 })(this);


### PR DESCRIPTION
Adds validation to only show warning message if debug is enabled.