### PR TITLE
Touch events - alpha version

### DIFF
--- a/editor/style.css
+++ b/editor/style.css
@@ -253,3 +253,8 @@ textarea {
 	font-size: 1em;
 }
 
+.graphcanvas{
+	/*touch-action: manipulation; WONT WORK*/
+	/*touch-action: none; DESIDERABLE: implement zoom and pan*/
+	touch-action: pinch-zoom;
+}

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -4495,7 +4495,7 @@ LGraphNode.prototype.executeAction = function(action)
         
 		var is_inside = !this.viewport || ( this.viewport && x >= this.viewport[0] && x < (this.viewport[0] + this.viewport[2]) && y >= this.viewport[1] && y < (this.viewport[1] + this.viewport[3]) );
 
-		console.log("pointerevents:: DragAndScale onMouse "+e.type+" "+is_inside);
+		//console.log("pointerevents: DragAndScale onMouse "+e.type+" "+is_inside);
 		
         var ignore = false;
         if (this.onmouse) {
@@ -4998,7 +4998,7 @@ LGraphNode.prototype.executeAction = function(action)
 
     //used in some events to capture them
     LGraphCanvas.prototype._doNothing = function doNothing(e) {
-    	console.log("pointerevents:: _doNothing "+e.type);
+    	//console.log("pointerevents: _doNothing "+e.type);
         e.preventDefault();
         return false;
     };
@@ -5017,7 +5017,7 @@ LGraphNode.prototype.executeAction = function(action)
             return;
         }
 
-        console.log("pointerevents:: binEvents");
+        //console.log("pointerevents: binEvents");
         
         var canvas = this.canvas;
 
@@ -5082,7 +5082,7 @@ LGraphNode.prototype.executeAction = function(action)
             return;
         }
 
-        console.log("pointerevents:: unbindEvents");
+        //console.log("pointerevents: unbindEvents");
         
         var ref_window = this.getCanvasWindow();
         var document = ref_window.document;
@@ -5256,7 +5256,7 @@ LGraphNode.prototype.executeAction = function(action)
 		var x = e.clientX;
 		var y = e.clientY;
 		//console.log(y,this.viewport);
-		console.log("pointerevents:: processMouseDown "+e.pointerId+" "+e.isPrimary+" :: "+x+" "+y);
+		//console.log("pointerevents: processMouseDown "+e.pointerId+" "+e.isPrimary+" :: "+x+" "+y);
 
 		this.ds.viewport = this.viewport;
 		var is_inside = !this.viewport || ( this.viewport && x >= this.viewport[0] && x < (this.viewport[0] + this.viewport[2]) && y >= this.viewport[1] && y < (this.viewport[1] + this.viewport[3]) );
@@ -5530,7 +5530,7 @@ LGraphNode.prototype.executeAction = function(action)
             }
 
             if (!skip_action && clicking_canvas_bg && this.allow_dragcanvas) {
-            	console.log("pointerevents:: dragging_canvas start");
+            	//console.log("pointerevents: dragging_canvas start");
             	this.dragging_canvas = true;
             }
             
@@ -5606,7 +5606,7 @@ LGraphNode.prototype.executeAction = function(action)
         this.graph_mouse[0] = e.canvasX;
         this.graph_mouse[1] = e.canvasY;
 
-        console.log("pointerevents:: processMouseMove "+e.pointerId+" "+e.isPrimary);
+        //console.log("pointerevents: processMouseMove "+e.pointerId+" "+e.isPrimary);
         //convertEventToCanvasOffset
         console.log(mouse);
         console.log(this.graph_mouse);
@@ -5614,7 +5614,7 @@ LGraphNode.prototype.executeAction = function(action)
         
 		if(this.block_click)
 		{
-			console.log("pointerevents:: processMouseMove block_click");
+			//console.log("pointerevents: processMouseMove block_click");
 			e.preventDefault();
 			return false;
 		}
@@ -5655,7 +5655,7 @@ LGraphNode.prototype.executeAction = function(action)
             }
             this.dirty_bgcanvas = true;
         } else if (this.dragging_canvas) {
-        	//console.log("pointerevents:: processMouseMove is dragging_canvas");
+        	////console.log("pointerevents: processMouseMove is dragging_canvas");
             this.ds.offset[0] += delta[0] / this.ds.scale;
             this.ds.offset[1] += delta[1] / this.ds.scale;
             this.dirty_canvas = true;
@@ -5820,11 +5820,11 @@ LGraphNode.prototype.executeAction = function(action)
     	if(e.isPrimary!==undefined && !e.isPrimary){
     		/*e.stopPropagation();
         	e.preventDefault();*/
-    		console.log("pointerevents:: processMouseUp pointerN_stop "+e.pointerId+" "+e.isPrimary);
+    		//console.log("pointerevents: processMouseUp pointerN_stop "+e.pointerId+" "+e.isPrimary);
     		return false;
     	}
     	
-    	console.log("pointerevents:: processMouseUp "+e.pointerId+" "+e.isPrimary+" :: "+e.clientX+" "+e.clientY);
+    	//console.log("pointerevents: processMouseUp "+e.pointerId+" "+e.isPrimary+" :: "+e.clientX+" "+e.clientY);
     	
 		if( this.set_canvas_dirty_on_mouse_event )
 			this.dirty_canvas = true;
@@ -5839,7 +5839,7 @@ LGraphNode.prototype.executeAction = function(action)
         //restore the mousemove event back to the canvas
 		if(!this.options.skip_events)
 		{
-			console.log("pointerevents:: processMouseUp removeEventListener");
+			//console.log("pointerevents: processMouseUp removeEventListener");
 			// why move listener from document to canvas?
 			document.removeEventListener(LiteGraph.pointerevents_method+"move",this._mousemove_callback,true);
 			this.canvas.addEventListener(LiteGraph.pointerevents_method+"move",this._mousemove_callback,true);
@@ -5854,11 +5854,11 @@ LGraphNode.prototype.executeAction = function(action)
 
 		if(this.block_click)
 		{
-			console.log("pointerevents:: processMouseUp block_clicks");
+			//console.log("pointerevents: processMouseUp block_clicks");
 			this.block_click = false; //used to avoid sending twice a click in a immediate button
 		}
 
-		console.log("pointerevents:: processMouseUp which: "+e.which);
+		//console.log("pointerevents: processMouseUp which: "+e.which);
 		
         if (e.which == 1) {
 
@@ -6076,7 +6076,7 @@ LGraphNode.prototype.executeAction = function(action)
 
         this.graph.change();
 
-        console.log("pointerevents:: processMouseUp stopPropagation");
+        //console.log("pointerevents: processMouseUp stopPropagation");
         e.stopPropagation();
         e.preventDefault();
         return false;
@@ -6688,7 +6688,7 @@ LGraphNode.prototype.executeAction = function(action)
         e.canvasX = clientX_rel / this.ds.scale - this.ds.offset[0];
         e.canvasY = clientY_rel / this.ds.scale - this.ds.offset[1];
         
-        console.log("pointerevents:: adjustMouseEvent "+e.clientX+":"+e.clientY+" "+clientX_rel+":"+clientY_rel+" "+e.canvasX+":"+e.canvasY);
+        //console.log("pointerevents: adjustMouseEvent "+e.clientX+":"+e.clientY+" "+clientX_rel+":"+clientY_rel+" "+e.canvasX+":"+e.canvasY);
     };
 
     /**

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -5019,7 +5019,7 @@ LGraphNode.prototype.executeAction = function(action)
         this._mousewheel_callback = this.processMouseWheel.bind(this);
         this._touch_callback = this.touchHandler.bind(this);
 
-        canvas.addEventListener("mousedown", this._mousedown_callback, true); //down do not need to store the binded
+        canvas.addEventListener("pointerdown", this._mousedown_callback, true); //down do not need to store the binded
         canvas.addEventListener("mousemove", this._mousemove_callback);
         canvas.addEventListener("mousewheel", this._mousewheel_callback, false);
 
@@ -5254,7 +5254,7 @@ LGraphNode.prototype.executeAction = function(action)
         var skip_dragging = false;
         var skip_action = false;
         var now = LiteGraph.getTime();
-        var is_double_click = now - this.last_mouseclick < 300;
+        var is_double_click = (now - this.last_mouseclick < 300) && (e.isPrimary);
 		this.mouse[0] = e.localX;
 		this.mouse[1] = e.localY;
         this.graph_mouse[0] = e.canvasX;

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -4444,9 +4444,9 @@ LGraphNode.prototype.executeAction = function(action)
 
         this._binded_mouse_callback = this.onMouse.bind(this);
 
-        element.addEventListener(LiteGraph.pointerevents_method+"down", this._binded_mouse_callback);
-        element.addEventListener(LiteGraph.pointerevents_method+"move", this._binded_mouse_callback);
-        element.addEventListener(LiteGraph.pointerevents_method+"up", this._binded_mouse_callback);
+		LiteGraph.pointerListenerAdd(element,"down", this._binded_mouse_callback);
+		LiteGraph.pointerListenerAdd(element,"move", this._binded_mouse_callback);
+		LiteGraph.pointerListenerAdd(element,"up", this._binded_mouse_callback);
 
         element.addEventListener(
             "mousewheel",
@@ -4504,9 +4504,9 @@ LGraphNode.prototype.executeAction = function(action)
 
         if (e.type == LiteGraph.pointerevents_method+"down" && is_inside) {
             this.dragging = true;
-            canvas.removeEventListener( LiteGraph.pointerevents_method+"move", this._binded_mouse_callback );
-            document.body.addEventListener( LiteGraph.pointerevents_method+"move", this._binded_mouse_callback );
-            document.body.addEventListener( LiteGraph.pointerevents_method+"up", this._binded_mouse_callback );
+			LiteGraph.pointerListenerRemove(canvas,"move",this._binded_mouse_callback);
+			LiteGraph.pointerListenerAdd(document,"move",this._binded_mouse_callback);
+			LiteGraph.pointerListenerAdd(document,"up",this._binded_mouse_callback);
         } else if (e.type == LiteGraph.pointerevents_method+"move") {
             if (!ignore) {
                 var deltax = x - this.last_mouse[0];
@@ -4517,9 +4517,9 @@ LGraphNode.prototype.executeAction = function(action)
             }
         } else if (e.type == LiteGraph.pointerevents_method+"up") {
             this.dragging = false;
-            document.body.removeEventListener( LiteGraph.pointerevents_method+"move", this._binded_mouse_callback );
-            document.body.removeEventListener( LiteGraph.pointerevents_method+"up", this._binded_mouse_callback );
-            canvas.addEventListener(LiteGraph.pointerevents_method+"move", this._binded_mouse_callback );
+			LiteGraph.pointerListenerRemove(document,"move",this._binded_mouse_callback);
+			LiteGraph.pointerListenerRemove(document,"up",this._binded_mouse_callback);
+			LiteGraph.pointerListenerAdd(canvas,"move",this._binded_mouse_callback);
         } else if ( is_inside &&
             (e.type == "mousewheel" ||
             e.type == "wheel" ||
@@ -5028,18 +5028,18 @@ LGraphNode.prototype.executeAction = function(action)
 
         this._mousedown_callback = this.processMouseDown.bind(this);
         this._mousewheel_callback = this.processMouseWheel.bind(this);
-        // why not binded here? this._mousemove_callback = this.processMouseMove.bind(this);
+        // why mousemove and mouseup were not binded here?
         this._mousemove_callback = this.processMouseMove.bind(this);
         this._mouseup_callback = this.processMouseUp.bind(this);
         
         //touch events -- THIS WAY DOES NOT WORK, finish implementing pointerevents, than clean the touchevents
         //this._touch_callback = this.touchHandler.bind(this);
 
-        canvas.addEventListener(LiteGraph.pointerevents_method+"down", this._mousedown_callback, true); //down do not need to store the binded
+		LiteGraph.pointerListenerAdd(canvas,"down", this._mousedown_callback, true); //down do not need to store the binded
         canvas.addEventListener("mousewheel", this._mousewheel_callback, false);
 
-        canvas.addEventListener(LiteGraph.pointerevents_method+"up", this._mouseup_callback, true);
-        canvas.addEventListener(LiteGraph.pointerevents_method+"move", this._mousemove_callback);
+        LiteGraph.pointerListenerAdd(canvas,"up", this._mouseup_callback, true); // CHECK: ??? binded or not
+		LiteGraph.pointerListenerAdd(canvas,"move", this._mousemove_callback);
         
         canvas.addEventListener("contextmenu", this._doNothing);
         canvas.addEventListener(
@@ -5089,9 +5089,9 @@ LGraphNode.prototype.executeAction = function(action)
         var ref_window = this.getCanvasWindow();
         var document = ref_window.document;
 
-        this.canvas.removeEventListener(LiteGraph.pointerevents_method+"move", this._mousedown_callback);
-        this.canvas.removeEventListener(LiteGraph.pointerevents_method+"up", this._mousedown_callback);
-        this.canvas.removeEventListener(LiteGraph.pointerevents_method+"down", this._mousedown_callback);
+		LiteGraph.pointerListenerRemove(this.canvas,"move", this._mousedown_callback);
+        LiteGraph.pointerListenerRemove(this.canvas,"up", this._mousedown_callback);
+        LiteGraph.pointerListenerRemove(this.canvas,"down", this._mousedown_callback);
         this.canvas.removeEventListener(
             "mousewheel",
             this._mousewheel_callback
@@ -5238,7 +5238,7 @@ LGraphNode.prototype.executeAction = function(action)
 		this.block_click = true;
 		this.last_mouseclick = 0;
 	}
-
+	
     LGraphCanvas.prototype.processMouseDown = function(e) {
     	
 		if( this.set_canvas_dirty_on_mouse_event )
@@ -5266,9 +5266,9 @@ LGraphNode.prototype.executeAction = function(action)
         //move mouse move event to the window in case it drags outside of the canvas
 		if(!this.options.skip_events)
 		{
-			this.canvas.removeEventListener(LiteGraph.pointerevents_method+"move", this._mousemove_callback);
-			ref_window.document.addEventListener( LiteGraph.pointerevents_method+"move", this._mousemove_callback, true ); //catch for the entire window
-			ref_window.document.addEventListener( LiteGraph.pointerevents_method+"up", this._mouseup_callback, true );
+			LiteGraph.pointerListenerRemove(this.canvas,"move", this._mousemove_callback);
+			LiteGraph.pointerListenerAdd(ref_window.document,"move", this._mousemove_callback,true); //catch for the entire window
+			LiteGraph.pointerListenerAdd(ref_window.document,"up", this._mouseup_callback,true);
 		}
 
 		if(!is_inside)
@@ -5846,11 +5846,10 @@ LGraphNode.prototype.executeAction = function(action)
         //restore the mousemove event back to the canvas
 		if(!this.options.skip_events)
 		{
-			//console.log("pointerevents: processMouseUp removeEventListener");
-			// why move listener from document to canvas?
-			document.removeEventListener(LiteGraph.pointerevents_method+"move",this._mousemove_callback,true);
-			this.canvas.addEventListener(LiteGraph.pointerevents_method+"move",this._mousemove_callback,true);
-			document.removeEventListener(LiteGraph.pointerevents_method+"up", this._mouseup_callback, true);
+			//console.log("pointerevents: processMouseUp adjustEventListener");
+			LiteGraph.pointerListenerRemove(document,"move", this._mousemove_callback,true);
+			LiteGraph.pointerListenerAdd(this.canvas,"move", this._mousemove_callback,true);
+			LiteGraph.pointerListenerRemove(document,"up", this._mouseup_callback,true);
 		}
 
         this.adjustMouseEvent(e);
@@ -9837,7 +9836,7 @@ LGraphNode.prototype.executeAction = function(action)
             dialog.style.transform = "scale(" + this.ds.scale + ")";
         }
 
-        dialog.addEventListener(LiteGraph.pointerevents_method+"leave", function(e) {
+		LiteGraph.pointerListenerAdd(dialog,"leave", function(e) {
             if (!modified) {
                 dialog.close();
             }
@@ -9942,14 +9941,14 @@ LGraphNode.prototype.executeAction = function(action)
             dialog.style.transform = "scale(" + this.ds.scale + ")";
         }
 
-        dialog.addEventListener(LiteGraph.pointerevents_method+"enter", function(e) {
+		LiteGraph.pointerListenerAdd(dialog,"enter", function(e) {
             if (timeout_close) {
                 clearTimeout(timeout_close);
                 timeout_close = null;
             }
         });
 
-        dialog.addEventListener(LiteGraph.pointerevents_method+"leave", function(e) {
+        LiteGraph.pointerListenerAdd(dialog,"leave", function(e) {
             //dialog.close();
             timeout_close = setTimeout(function() {
                 dialog.close();
@@ -11564,8 +11563,7 @@ LGraphNode.prototype.executeAction = function(action)
         }, 100); //delay so the mouse up event is not caught by this element
 
         //this prevents the default context browser menu to open in case this menu was created when pressing right button
-        root.addEventListener(
-            LiteGraph.pointerevents_method+"up",
+		LiteGraph.pointerListenerAdd(root,"up",
             function(e) {
 			  	//console.log("pointerevents: ContextMenu up root prevent");
                 e.preventDefault();
@@ -11586,8 +11584,7 @@ LGraphNode.prototype.executeAction = function(action)
             true
         );
 
-        root.addEventListener(
-            LiteGraph.pointerevents_method+"down",
+        LiteGraph.pointerListenerAdd(root,"down",
             function(e) {
 			  	//console.log("pointerevents: ContextMenu down");
                 if (e.button == 2) {
@@ -11636,8 +11633,8 @@ LGraphNode.prototype.executeAction = function(action)
             num++;
         }
 
-        //close on leave? touch enabled devices won't work 
-        /*root.addEventListener(LiteGraph.pointerevents_method+"leave", function(e) {
+        //close on leave? touch enabled devices won't work TODO use a global device detector and condition on that
+        /*LiteGraph.pointerListenerAdd(root,"leave", function(e) {
 		  	console.log("pointerevents: ContextMenu leave");
             if (that.lock) {
                 return;
@@ -11649,7 +11646,7 @@ LGraphNode.prototype.executeAction = function(action)
             //that.close(e);
         });*/
 
-        root.addEventListener(LiteGraph.pointerevents_method+"enter", function(e) {
+		LiteGraph.pointerListenerAdd(root,"enter", function(e) {
 		  	//console.log("pointerevents: ContextMenu enter");
             if (root.closing_timer) {
                 clearTimeout(root.closing_timer);
@@ -11751,7 +11748,7 @@ LGraphNode.prototype.executeAction = function(action)
             element.addEventListener("click", inner_onclick);
         }
         if (options.autoopen) {
-            element.addEventListener(LiteGraph.pointerevents_method+"enter", inner_over);
+			LiteGraph.pointerListenerAdd(element,"enter",inner_over);
         }
 
         function inner_over(e) {
@@ -12163,6 +12160,54 @@ LGraphNode.prototype.executeAction = function(action)
             .filter(Boolean); // split & filter [""]
     };
 
+	// helper pointerListener vs mouseListener, used by LGraphCanvas DragAndScale ContextMenu
+	LiteGraph.pointerListenerAdd = function(oDOM, sEvent, fCall, capture=false) {
+		if (!oDOM || !oDOM.addEventListener || !sEvent || typeof fCall!=="function"){
+			console.log("cant pointerListenerAdd "+oDOM+", "+sEvent+", "+fCall);
+			return; // -- break --
+		}
+		switch(sEvent){
+			//both pointer and move events
+			case "down": case "up": case "move": case "over": case "out": case "enter":
+			{
+				oDOM.addEventListener(LiteGraph.pointerevents_method+sEvent, fCall, capture);
+			}
+			// only pointerevents
+			case "leave": case "cancel": case "gotpointercapture": case "lostpointercapture":
+			{
+				if (LiteGraph.pointerevents_method!="mouse"){
+					return oDOM.addEventListener(LiteGraph.pointerevents_method+sEvent, fCall, capture);
+				}
+			}
+			// not "pointer" || "mouse"
+			default:
+				return oDOM.addEventListener(sEvent, fCall, capture);
+		}
+	}
+	LiteGraph.pointerListenerRemove = function(oDOM, sEvent, fCall, capture=false) {
+		if (!oDOM || !oDOM.removeEventListener || !sEvent || typeof fCall!=="function"){
+			console.log("cant pointerListenerRemove "+oDOM+", "+sEvent+", "+fCall);
+			return; // -- break --
+		}
+		switch(sEvent){
+			//both pointer and move events
+			case "down": case "up": case "move": case "over": case "out": case "enter":
+			{
+				oDOM.removeEventListener(LiteGraph.pointerevents_method+sEvent, fCall, capture);
+			}
+			// only pointerevents
+			case "leave": case "cancel": case "gotpointercapture": case "lostpointercapture":
+			{
+				if (LiteGraph.pointerevents_method!="mouse"){
+					return oDOM.removeEventListener(LiteGraph.pointerevents_method+sEvent, fCall, capture);
+				}
+			}
+			// not "pointer" || "mouse"
+			default:
+				return oDOM.removeEventListener(sEvent, fCall, capture);
+		}
+	}
+	
     Math.clamp = function(v, a, b) {
         return a > v ? a : b < v ? b : v;
     };


### PR DESCRIPTION
Touch device compatibility
- drag canvas, operate on nodes, widgets, slots
- right click simulation when second pointer is down

added LiteGraph.pointerevents_method variable ("pointer" | "mouse"), default "pointer"
replaced (Add/Remove)EventListeners with helper Litegraph.pointerListener(Add/Remove)
checks for e.isPrimary to discriminate one or more fingers down

TODO: finish checks and clean
_will remove console.log("pointerevents..) calls en integration concluded_
_multitouch gestures will be implemented on a successive tranche (pan, pinch, swipe ..)_