### PR TITLE
Pack

### DIFF
--- a/css/litegraph-editor.css
+++ b/css/litegraph-editor.css
@@ -202,6 +202,7 @@
 	overflow: auto;
 	resize: none;
 	outline: none;
+    color: #DDD;
 }
 
 .litegraph-editor .codeflask {

--- a/css/litegraph.css
+++ b/css/litegraph.css
@@ -206,6 +206,20 @@
     padding-top: 2px;
 }
 
+.litegraph.lite-search-item.not_in_filter{
+    /*background-color: rgba(50, 50, 50, 0.5);*/
+    /*color: #999;*/
+    color: #B99;
+    font-style: italic;
+}
+
+.litegraph.lite-search-item.generic_type{
+    /*background-color: rgba(50, 50, 50, 0.5);*/
+    /*color: #DD9;*/
+    color: #999;
+    font-style: italic;
+}
+
 .litegraph.lite-search-item:hover,
 .litegraph.lite-search-item.selected {
     cursor: pointer;
@@ -234,6 +248,18 @@
 	left: 10px;
 	top: 10px;
 	height: calc( 100% - 20px );
+	margin: auto;
+    max-width: 50%;
+}
+
+.litegraph .dialog.centered {
+    top: 50px;
+    left: 50%;
+    position: absolute;
+    transform: translateX(-50%);
+    min-width: 600px;
+    min-height: 300px;
+    height: calc( 100% - 100px );
 	margin: auto;
 }
 
@@ -264,13 +290,14 @@
     display: inline-block;
 }
 
-.litegraph .dialog .dialog-content {
+.litegraph .dialog .dialog-content, .litegraph .dialog .dialog-alt-content {
     height: calc(100% - 90px);
     width: 100%;
 	min-height: 100px;
     display: inline-block;
 	color: #AAA;
     /*background-color: black;*/
+    overflow: auto;
 }
 
 .litegraph .dialog .dialog-content h3 {
@@ -315,14 +342,23 @@
 	padding: 4px;
 }
 
+.litegraph .dialog .property:hover {
+	background: #545454;
+}
+
 .litegraph .dialog .property_name {
 	color: #737373;
     display: inline-block;
     text-align: left;
     vertical-align: top;
-    width: 120px;
+    width: 160px;
 	padding-left: 4px;
 	overflow: hidden;
+    margin-right: 6px;
+}
+
+.litegraph .dialog .property:hover .property_name {
+    color: white;
 }
 
 .litegraph .dialog .property_value {
@@ -330,8 +366,11 @@
     text-align: right;
 	color: #AAA;
 	background-color: #1A1A1A;
-    width: calc( 100% - 122px );
+    /*width: calc( 100% - 122px );*/
+    max-width: calc( 100% - 162px );
+    min-width: 200px;
 	max-height: 300px;
+    min-height: 20px;
     padding: 4px;
 	padding-right: 12px;
 	overflow: hidden;
@@ -345,6 +384,16 @@
 
 .litegraph .dialog .property.boolean .property_value {
 	padding-right: 30px;
+    color: #A88;
+    /*width: auto;
+    float: right;*/
+}
+
+.litegraph .dialog .property.boolean.bool-on .property_name{
+    color: #8A8;
+}
+.litegraph .dialog .property.boolean.bool-on .property_value{
+    color: #8A8;
 }
 
 .litegraph .dialog .btn {
@@ -515,7 +564,7 @@
     position: absolute;
     top: 10px;
     left: 10px;
-    /*min-height: 2em;*/
+    min-height: 2em;
     background-color: #333;
     font-size: 1.2em;
     box-shadow: 0 0 10px black !important;

--- a/editor/editor_mobile.html
+++ b/editor/editor_mobile.html
@@ -1,0 +1,144 @@
+<!-- Javi Agenjo (@tamat) on 31/9/2011 -->
+<!DOCTYPE html>
+<html>
+<head>
+    <title>LiteGraph</title>
+	<!--<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">-->
+	<meta http-equiv="X-UA-Compatible" content="chrome=1">
+
+    <link rel="stylesheet" type="text/css" href="../css/litegraph.css">
+    <link rel="stylesheet" type="text/css" href="../css/litegraph-editor.css">
+    <link rel="stylesheet" type="text/css" href="style.css">
+    
+</head>
+<body>
+	<div id="main">
+	</div>
+
+    <script type="text/javascript" src="../external/jquery-1.6.2.min.js"></script>
+    <script type="text/javascript" src="https://tamats.com/projects/sillyserver/src/sillyclient.js"></script>
+	<!-- <script type="text/javascript" src="https://unpkg.com/codeflask/build/codeflask.min.js"></script> -->
+	<script type="text/javascript" src="js/libs/gl-matrix-min.js"></script>
+    <script type="text/javascript" src="js/libs/audiosynth.js"></script>
+    <script type="text/javascript" src="js/libs/midi-parser.js"></script>
+
+    <script type="text/javascript" src="../src/litegraph.js"></script>
+    <script type="text/javascript" src="../src/litegraph-editor.js"></script>
+    <script type="text/javascript" src="js/defaults_mobile.js"></script>
+
+    <script type="text/javascript" src="../src/nodes/base.js"></script>
+    <script type="text/javascript" src="../src/nodes/logic.js"></script>
+    <script type="text/javascript" src="../src/nodes/events.js"></script>
+    <script type="text/javascript" src="../src/nodes/math.js"></script>
+    <script type="text/javascript" src="../src/nodes/math3d.js"></script>
+    <script type="text/javascript" src="../src/nodes/strings.js"></script>
+    <script type="text/javascript" src="../src/nodes/interface.js"></script>
+    <script type="text/javascript" src="../src/nodes/geometry.js"></script>
+    <script type="text/javascript" src="../src/nodes/graphics.js"></script>
+    <script type="text/javascript" src="../src/nodes/input.js"></script>
+    <script type="text/javascript" src="../src/nodes/midi.js"></script>
+    <script type="text/javascript" src="../src/nodes/audio.js"></script>
+    <script type="text/javascript" src="../src/nodes/network.js"></script>
+
+    <script type="text/javascript" src="js/demos.js"></script>
+	<script type="text/javascript" src="js/code.js"></script>
+
+	<script type="text/javascript" src="../src/nodes/others.js"></script>
+
+	<!--  htmlConsole use to debug on mobile, include and set editorUseHtmlConsole in defaults.js -->
+	<!-- enable console style, html, js enabling/disabling this comment here->  -->
+		
+	    <link rel="stylesheet" href="//htmlacademy.github.io/console.js/latest/css/style.css">
+	    <style>
+	    	.invisible{ display: none; }
+	    	.console__row{
+	    		margin: 1px;
+				padding: 2px;
+			}
+			.console-container{
+				min-width: 200px;
+				background: rgba(255,255,255,0.1);
+				position: fixed;
+				top: 38px;
+				left: 0;
+				overflow: auto;
+				height: calc(100%-38px);
+			}
+			.console-container.small{
+				max-width: 30%;
+			}
+			.graphcanvas{
+				/*WONT WORK touch-action: manipulation;*/
+				/*touch-action: none;*/
+				touch-action: pinch-zoom;
+			}
+	    </style>
+		
+		<div id="console-container" class="litegraph-editor console-container small invisible" style="">
+			<div class="console-tools" style="position: absolute; top: 0; right:0; z-index:2;">
+				<button class='btn' id='btn_console_close'>close</button>
+				<button class='btn' id='btn_console_clear'>clear</button>
+			</div>
+		</div>
+		
+		<script src="//htmlacademy.github.io/console.js/latest/js/index.js"></script>
+		<script>
+		
+			var editorUseHtmlConsole = true; // enable html console to debug on mobile
+		
+			// ToBarSelector
+			if(editorUseHtmlConsole){
+				document.getElementById("LGEditorTopBarSelector").innerHTML = "<button class='btn' id='btn_console'>Console</button> "
+																				+document.getElementById("LGEditorTopBarSelector").innerHTML;
+			}
+			
+			// html console
+			if(editorUseHtmlConsole){
+				elem.querySelector("#btn_console").addEventListener("click", function(){
+					var consoleCnt = document.getElementById('console-container');
+					if (consoleCnt.classList.contains("invisible")){
+						consoleCnt.classList.remove("invisible");
+					}else{
+						jsConsole.clean();
+						consoleCnt.classList.add("invisible");
+					}	
+				});
+				
+			
+				const params = {
+					expandDepth : 1,
+					common : {
+						excludeProperties : ['__proto__'],
+						removeProperties: ['__proto__'],
+						maxFieldsInHead : 5,
+						minFieldsToAutoexpand : 5,
+						maxFieldsToAutoexpand : 15
+					}
+				};
+				var jsConsole = new Console(document.querySelector('.console-container'), params);
+				jsConsole.log("Here is console.log!");
+			    
+				// map console log-debug to jsConsole
+				console.log = function(par){
+			    	jsConsole.log(par);
+			    	var objDiv = document.getElementById("console-container");
+					objDiv.scrollTop = objDiv.scrollHeight;
+			    }
+			    console.debug = console.log;
+			    
+			    console.log("going into html console");
+			    
+			    document.getElementById("btn_console_clear").addEventListener("click", function(){
+			    	var consoleCnt = document.getElementById('console-container');
+			    	jsConsole.clean();
+			    });
+			    document.getElementById("btn_console_close").addEventListener("click", function(){
+			    	var consoleCnt = document.getElementById('console-container');
+			    	consoleCnt.classList.add("invisible");
+			    });
+			}
+		</script>
+	<!--  -->
+
+</body>
+</html>

--- a/editor/index.html
+++ b/editor/index.html
@@ -22,6 +22,7 @@
 
     <script type="text/javascript" src="../src/litegraph.js"></script>
     <script type="text/javascript" src="../src/litegraph-editor.js"></script>
+    <script type="text/javascript" src="js/defaults.js"></script>
 
     <script type="text/javascript" src="../src/nodes/base.js"></script>
     <script type="text/javascript" src="../src/nodes/logic.js"></script>
@@ -39,6 +40,8 @@
 
     <script type="text/javascript" src="js/demos.js"></script>
 	<script type="text/javascript" src="js/code.js"></script>
+
+	<script type="text/javascript" src="../src/nodes/others.js"></script>
 
 </body>
 </html>

--- a/editor/js/code.js
+++ b/editor/js/code.js
@@ -1,6 +1,7 @@
 var webgl_canvas = null;
 
 LiteGraph.node_images_path = "../nodes_data/";
+
 var editor = new LiteGraph.Editor("main",{miniwindow:false});
 window.graphcanvas = editor.graphcanvas;
 window.graph = editor.graph;
@@ -19,8 +20,10 @@ LiteGraph.allow_scripts = true;
 
 //create scene selector
 var elem = document.createElement("span");
+elem.id = "LGEditorTopBarSelector";
 elem.className = "selector";
-elem.innerHTML = "Demo <select><option>Empty</option></select> <button class='btn' id='save'>Save</button><button class='btn' id='load'>Load</button><button class='btn' id='download'>Download</button> | <button class='btn' id='webgl'>WebGL</button> <button class='btn' id='multiview'>Multiview</button>";
+elem.innerHTML = "";
+elem.innerHTML += "Demo <select><option>Empty</option></select> <button class='btn' id='save'>Save</button><button class='btn' id='load'>Load</button><button class='btn' id='download'>Download</button> | <button class='btn' id='webgl'>WebGL</button> <button class='btn' id='multiview'>Multiview</button>";
 editor.tools.appendChild(elem);
 var select = elem.querySelector("select");
 select.addEventListener("change", function(e){

--- a/editor/js/defaults.js
+++ b/editor/js/defaults.js
@@ -1,0 +1,31 @@
+
+LiteGraph.debug = false;
+LiteGraph.catch_exceptions = true;
+LiteGraph.throw_errors = true;
+LiteGraph.allow_scripts = false; //if set to true some nodes like Formula would be allowed to evaluate code that comes from unsafe sources (like node configuration); which could lead to exploits
+
+LiteGraph.searchbox_extras = {}; //used to add extra features to the search box
+LiteGraph.auto_sort_node_types = true; // [true!] If set to true; will automatically sort node types / categories in the context menus
+LiteGraph.node_box_coloured_when_on = true; // [true!] this make the nodes box (top left circle) coloured when triggered (execute/action); visual feedback
+LiteGraph.node_box_coloured_by_mode = true; // [true!] nodebox based on node mode; visual feedback
+LiteGraph.dialog_close_on_mouse_leave = true; // [false on mobile] better true if not touch device;
+LiteGraph.dialog_close_on_mouse_leave_delay = 500;
+LiteGraph.shift_click_do_break_link_from = false; // [false!] prefer false if results too easy to break links
+LiteGraph.click_do_break_link_to = false; // [false!]prefer false; way too easy to break links
+LiteGraph.search_hide_on_mouse_leave = true; // [false on mobile] better true if not touch device;
+LiteGraph.search_filter_enabled = true; // [true!] enable filtering slots type in the search widget; !requires auto_load_slot_types or manual set registered_slot_[in/out]_types and slot_types_[in/out]
+LiteGraph.search_show_all_on_open = true; // [true!] opens the results list when opening the search widget
+
+LiteGraph.auto_load_slot_types = true; // [if want false; use true; run; get vars values to be statically set; than disable] nodes types and nodeclass association with node types need to be calculated; if dont want this; calculate once and set registered_slot_[in/out]_types and slot_types_[in/out]
+/*// set these values if not using auto_load_slot_types
+LiteGraph.registered_slot_in_types = {}; // slot types for nodeclass
+LiteGraph.registered_slot_out_types = {}; // slot types for nodeclass
+LiteGraph.slot_types_in = []; // slot types IN
+LiteGraph.slot_types_out = []; // slot types OUT*/
+
+LiteGraph.alt_drag_do_clone_nodes = true; // [true!] very handy; ALT click to clone and drag the new node
+LiteGraph.do_add_triggers_slots = true; // [true!] will create and connect event slots when using action/events connections; !WILL CHANGE node mode when using onTrigger (enable mode colors); onExecuted does not need this
+LiteGraph.allow_multi_output_for_events = false; // [false!] being events; it is strongly reccomended to use them sequentually; one by one
+LiteGraph.middle_click_slot_add_default_node = true;  //[true!] allows to create and connect a ndoe clicking with the third button (wheel)
+LiteGraph.release_link_on_empty_shows_menu = true; //[true!] dragging a link to empty space will open a menu, add from list, search or defaults
+LiteGraph.pointerevents_method = "pointer"; // "mouse"|"pointer" use mouse for retrocompatibility issues? (none found @ now)

--- a/editor/js/defaults_mobile.js
+++ b/editor/js/defaults_mobile.js
@@ -1,0 +1,31 @@
+
+LiteGraph.debug = false;
+LiteGraph.catch_exceptions = true;
+LiteGraph.throw_errors = true;
+LiteGraph.allow_scripts = false; //if set to true some nodes like Formula would be allowed to evaluate code that comes from unsafe sources (like node configuration); which could lead to exploits
+
+LiteGraph.searchbox_extras = {}; //used to add extra features to the search box
+LiteGraph.auto_sort_node_types = true; // [true!] If set to true; will automatically sort node types / categories in the context menus
+LiteGraph.node_box_coloured_when_on = true; // [true!] this make the nodes box (top left circle) coloured when triggered (execute/action); visual feedback
+LiteGraph.node_box_coloured_by_mode = true; // [true!] nodebox based on node mode; visual feedback
+LiteGraph.dialog_close_on_mouse_leave = false; // [false on mobile] better true if not touch device;
+LiteGraph.dialog_close_on_mouse_leave_delay = 500;
+LiteGraph.shift_click_do_break_link_from = false; // [false!] prefer false if results too easy to break links
+LiteGraph.click_do_break_link_to = false; // [false!]prefer false; way too easy to break links
+LiteGraph.search_hide_on_mouse_leave = false; // [false on mobile] better true if not touch device;
+LiteGraph.search_filter_enabled = true; // [true!] enable filtering slots type in the search widget; !requires auto_load_slot_types or manual set registered_slot_[in/out]_types and slot_types_[in/out]
+LiteGraph.search_show_all_on_open = true; // [true!] opens the results list when opening the search widget
+
+LiteGraph.auto_load_slot_types = true; // [if want false; use true; run; get vars values to be statically set; than disable] nodes types and nodeclass association with node types need to be calculated; if dont want this; calculate once and set registered_slot_[in/out]_types and slot_types_[in/out]
+/*// set these values if not using auto_load_slot_types
+LiteGraph.registered_slot_in_types = {}; // slot types for nodeclass
+LiteGraph.registered_slot_out_types = {}; // slot types for nodeclass
+LiteGraph.slot_types_in = []; // slot types IN
+LiteGraph.slot_types_out = []; // slot types OUT*/
+
+LiteGraph.alt_drag_do_clone_nodes = true; // [true!] very handy; ALT click to clone and drag the new node
+LiteGraph.do_add_triggers_slots = true; // [true!] will create and connect event slots when using action/events connections; !WILL CHANGE node mode when using onTrigger (enable mode colors); onExecuted does not need this
+LiteGraph.allow_multi_output_for_events = false; // [false!] being events; it is strongly reccomended to use them sequentually; one by one
+LiteGraph.middle_click_slot_add_default_node = true;  //[true!] allows to create and connect a ndoe clicking with the third button (wheel)
+LiteGraph.release_link_on_empty_shows_menu = true; //[true!] dragging a link to empty space will open a menu, add from list, search or defaults
+LiteGraph.pointerevents_method = "pointer"; // "mouse"|"pointer" use mouse for retrocompatibility issues? (none found @ now)

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -7798,7 +7798,7 @@ LGraphNode.prototype.executeAction = function(action)
         ctx.fillStyle = "#111";
         ctx.globalAlpha = 0.8;
         ctx.beginPath();
-        ctx.roundRect(10, 10, w, (num + 1) * h + 50, 8);
+        ctx.roundRect(10, 10, w, (num + 1) * h + 50, [8]);
         ctx.fill();
         ctx.globalAlpha = 1;
 
@@ -7867,7 +7867,7 @@ LGraphNode.prototype.executeAction = function(action)
         ctx.fillStyle = "#111";
         ctx.globalAlpha = 0.8;
         ctx.beginPath();
-        ctx.roundRect(canvas_w - w - 10, 10, w, (num + 1) * h + 50, 8);
+        ctx.roundRect(canvas_w - w - 10, 10, w, (num + 1) * h + 50, [8]);
         ctx.fill();
         ctx.globalAlpha = 1;
 
@@ -7945,7 +7945,7 @@ LGraphNode.prototype.executeAction = function(action)
 		if(clicked)
 			ctx.fillStyle = "#AAA";
 		ctx.beginPath();
-		ctx.roundRect(x,y,w,h,4 );
+		ctx.roundRect(x,y,w,h,[4] );
 		ctx.fill();
 
 		if(text != null)
@@ -8659,7 +8659,7 @@ LGraphNode.prototype.executeAction = function(action)
 		ctx.shadowBlur = 3;
 		ctx.fillStyle = "#454";
 		ctx.beginPath();
-		ctx.roundRect( pos[0] - w*0.5, pos[1] - 15 - h, w, h,3, 3);
+		ctx.roundRect( pos[0] - w*0.5, pos[1] - 15 - h, w, h, [3]);
 		ctx.moveTo( pos[0] - 10, pos[1] - 15 );
 		ctx.lineTo( pos[0] + 10, pos[1] - 15 );
 		ctx.lineTo( pos[0], pos[1] - 5 );
@@ -8728,8 +8728,7 @@ LGraphNode.prototype.executeAction = function(action)
                     area[1],
                     area[2],
                     area[3],
-                    this.round_radius,
-                    shape == LiteGraph.CARD_SHAPE ? 0 : this.round_radius
+                    shape == LiteGraph.CARD_SHAPE ? [this.round_radius,this.round_radius,0,0] : [this.round_radius] 
                 );
             } else if (shape == LiteGraph.CIRCLE_SHAPE) {
                 ctx.arc(
@@ -8794,8 +8793,7 @@ LGraphNode.prototype.executeAction = function(action)
                         -title_height,
                         size[0] + 1,
                         title_height,
-                        this.round_radius,
-                        node.flags.collapsed ? this.round_radius : 0
+                        node.flags.collapsed ? [this.round_radius] : [this.round_radius,this.round_radius,0,0]
                     );
                 }
                 ctx.fill();
@@ -8922,7 +8920,7 @@ LGraphNode.prototype.executeAction = function(action)
 				else
 				{
 					ctx.beginPath();
-					ctx.roundRect(x+2, -w+2, w-4, w-4,4);
+					ctx.roundRect(x+2, -w+2, w-4, w-4,[4]);
 					ctx.fill();
 				}
 				ctx.fillStyle = "#333";
@@ -8968,7 +8966,7 @@ LGraphNode.prototype.executeAction = function(action)
                     -6 + area[1],
                     12 + area[2],
                     12 + area[3],
-                    this.round_radius * 2
+                    [this.round_radius * 2]
                 );
             } else if (shape == LiteGraph.CARD_SHAPE) {
                 ctx.roundRect(
@@ -8976,8 +8974,7 @@ LGraphNode.prototype.executeAction = function(action)
                     -6 + area[1],
                     12 + area[2],
                     12 + area[3],
-                    this.round_radius * 2,
-                    2
+                    [this.round_radius * 2,2,this.round_radius * 2,2]
                 );
             } else if (shape == LiteGraph.CIRCLE_SHAPE) {
                 ctx.arc(
@@ -9571,7 +9568,7 @@ LGraphNode.prototype.executeAction = function(action)
                     ctx.fillStyle = background_color;
                     ctx.beginPath();
                     if (show_text)
-	                    ctx.roundRect(margin, posY, widget_width - margin * 2, H, H * 0.5);
+	                    ctx.roundRect(margin, posY, widget_width - margin * 2, H, [H * 0.5]);
 					else
 	                    ctx.rect(margin, posY, widget_width - margin * 2, H );
                     ctx.fill();
@@ -9628,7 +9625,7 @@ LGraphNode.prototype.executeAction = function(action)
                     ctx.fillStyle = background_color;
                     ctx.beginPath();
 					if(show_text)
-	                    ctx.roundRect(margin, posY, widget_width - margin * 2, H, H * 0.5);
+	                    ctx.roundRect(margin, posY, widget_width - margin * 2, H, [H * 0.5] );
 					else
 	                    ctx.rect(margin, posY, widget_width - margin * 2, H );
                     ctx.fill();
@@ -9688,7 +9685,7 @@ LGraphNode.prototype.executeAction = function(action)
                     ctx.fillStyle = background_color;
                     ctx.beginPath();
                     if (show_text)
-	                    ctx.roundRect(margin, posY, widget_width - margin * 2, H, H * 0.5);
+	                    ctx.roundRect(margin, posY, widget_width - margin * 2, H, [H * 0.5]);
 					else
 	                    ctx.rect( margin, posY, widget_width - margin * 2, H );
                     ctx.fill();

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -113,14 +113,14 @@
         click_do_break_link_to: false, // [false!]prefer false, way too easy to break links
         
         search_hide_on_mouse_leave: true, // [false on mobile] better true if not touch device, TODO add an helper/listener to close if false
-        search_filter_enabled: true, // [true!] enable filtering slots type in the search widget, !requires auto_load_slot_types
+        search_filter_enabled: false, // [true!] enable filtering slots type in the search widget, !requires auto_load_slot_types or manual set registered_slot_[in/out]_types and slot_types_[in/out]
         search_show_all_on_open: true, // [true!] opens the results list when opening the search widget
         
-        auto_load_slot_types: true, // [if want false, use true, run, get vars values to be statically set, than disable] nodes types and nodeclass association with node types need to be calculated, if dont want this, calculate once and set registered_slot_[in/out]_types and slot_types_[in/out]
+        auto_load_slot_types: false, // [if want false, use true, run, get vars values to be statically set, than disable] nodes types and nodeclass association with node types need to be calculated, if dont want this, calculate once and set registered_slot_[in/out]_types and slot_types_[in/out]
         
+		// set these values if not using auto_load_slot_types
         registered_slot_in_types: {}, // slot types for nodeclass
         registered_slot_out_types: {}, // slot types for nodeclass
-        
         slot_types_in: [], // slot types IN
         slot_types_out: [], // slot types OUT
         
@@ -3098,7 +3098,11 @@
             // enable this to give the event an ID
 			if (!options.action_call) options.action_call = this.id+"_exec_"+Math.floor(Math.random()*9999);
             
-            this.graph.nodes_executing[this.id] = true; //.push(this.id);
+            if (this.graph.nodes_executing) this.graph.nodes_executing[this.id] = true; //.push(this.id);
+			else{
+				this.graph.nodes_executing = {};
+				this.graph.nodes_executing[this.id] = true;
+			}
             
             this.onExecute(param, options);
             
@@ -10815,7 +10819,7 @@ LGraphNode.prototype.executeAction = function(action)
         def_options = { slot_from: null
                         ,node_from: null
                         ,node_to: null
-                        ,do_type_filter: LiteGraph.auto_load_slot_types && LiteGraph.search_filter_enabled // this will be checked for functionality enabled : filter on slot type, in and out
+                        ,do_type_filter: LiteGraph.search_filter_enabled // TODO check for registered_slot_[in/out]_types not empty // this will be checked for functionality enabled : filter on slot type, in and out
                         ,type_filter_in: false                          // these are default: pass to set initially set values
                         ,type_filter_out: false
                         ,show_general_if_none_on_typefilter: true

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -614,7 +614,7 @@
 			if (type_a=="" || type_a==="*") type_a = 0;
 			if (type_b=="" || type_b==="*") type_b = 0;
             if (
-                !generic //generic output
+                !type_a //generic output
                 || !type_b // generic input
                 || type_a == type_b //same type (is valid for triggers)
                 || (type_a == LiteGraph.EVENT && type_b == LiteGraph.ACTION)

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -1045,6 +1045,9 @@
         this.iteration += 1;
         this.elapsed_time = (now - this.last_update_time) * 0.001;
         this.last_update_time = now;
+        this.nodes_executing = [];
+        this.nodes_actioning = [];
+        this.nodes_executedAction = [];
     };
 
     /**
@@ -4004,24 +4007,24 @@
         }
         target_slot = target_node.findInputSlotByType(target_slotType, false, true);
         if (target_slot >= 0 && target_slot !== null){
-            console.debug("CONNbyTYPE type "+target_slotType+" for "+target_slot)
+            //console.debug("CONNbyTYPE type "+target_slotType+" for "+target_slot)
             return this.connect(slot, target_node, target_slot);
         }else{
-            console.log("type "+target_slotType+" not found or not free?")
+            //console.log("type "+target_slotType+" not found or not free?")
             if (opts.createEventInCase && target_slotType == LiteGraph.EVENT){
                 // WILL CREATE THE onTrigger IN SLOT
-				console.debug("connect WILL CREATE THE onTrigger "+target_slotType+" to "+target_node);
+				//console.debug("connect WILL CREATE THE onTrigger "+target_slotType+" to "+target_node);
                 return this.connect(slot, target_node, -1);
             }
             if (opts.generalTypeInCase && (target_slotType !== 0 && target_slotType !== "" && target_slotType !== "*")){
                 // connect TO a general type (*, 0), if not found the specific type
-				console.debug("connect TO a general type (*, 0), if not found the specific type "+target_slotType+" to "+target_node);
+				//console.debug("connect TO a general type (*, 0), if not found the specific type "+target_slotType+" to "+target_node);
                 target_slot = target_node.findInputSlotByType(0, false, true);
                 if (target_slot >= 0 && target_slot !== null){
                     return this.connect(slot, target_node, target_slot);
                 }
             }else{
-                console.debug("no way to connect "+target_slotType+" to "+target_node);
+                //console.debug("no way to connect "+target_slotType+" to "+target_node);
             }
             return null;
         }
@@ -7932,11 +7935,11 @@ LGraphNode.prototype.executeAction = function(action)
 		bgcolor = bgcolor || LiteGraph.NODE_DEFAULT_COLOR;
 		hovercolor = hovercolor || "#555";
 		textcolor = textcolor || LiteGraph.NODE_TEXT_COLOR;
-
+		var yFix = y + LiteGraph.NODE_TITLE_HEIGHT + 2;	// fix the height with the title
 		var pos = this.mouse;
-		var hover = LiteGraph.isInsideRectangle( pos[0], pos[1], x,y,w,h );
+		var hover = LiteGraph.isInsideRectangle( pos[0], pos[1], x,yFix,w,h );
 		pos = this.last_click_position;
-		var clicked = pos && LiteGraph.isInsideRectangle( pos[0], pos[1], x,y,w,h );
+		var clicked = pos && LiteGraph.isInsideRectangle( pos[0], pos[1], x,yFix,w,h );
 
 		ctx.fillStyle = hover ? hovercolor : bgcolor;
 		if(clicked)
@@ -10826,7 +10829,7 @@ LGraphNode.prototype.executeAction = function(action)
                     };
         options = Object.assign(def_options, options || {});
         
-		console.log(options);
+		//console.log(options);
 		
         var that = this;
         var input_html = "";
@@ -11335,7 +11338,7 @@ LGraphNode.prototype.executeAction = function(action)
                         //if (sV.toLowerCase() == "event/action") sV = LiteGraph.EVENT; // -1
                         
                         if(sOut && sV){
-                            console.log("will check filter against "+sV);
+                            //console.log("search will check filter against "+sV);
                             if (LiteGraph.registered_slot_out_types[sV] && LiteGraph.registered_slot_out_types[sV].nodes){ // type is stored
                                 //console.debug("check "+sType+" in "+LiteGraph.registered_slot_out_types[sV].nodes);
                                 var doesInc = LiteGraph.registered_slot_out_types[sV].nodes.includes(sType);
@@ -11788,7 +11791,7 @@ LGraphNode.prototype.executeAction = function(action)
 
 			function innerChange(name, value)
 			{
-				console.log("change",name,value);
+				//console.log("change",name,value);
 				//that.dirty_canvas = true;
 				if(options.callback)
 					options.callback(name,value,options);
@@ -13571,7 +13574,7 @@ LGraphNode.prototype.executeAction = function(action)
 	// helper pointerListener vs mouseListener, used by LGraphCanvas DragAndScale ContextMenu
 	LiteGraph.pointerListenerAdd = function(oDOM, sEvent, fCall, capture=false) {
 		if (!oDOM || !oDOM.addEventListener || !sEvent || typeof fCall!=="function"){
-			console.log("cant pointerListenerAdd "+oDOM+", "+sEvent+", "+fCall);
+			//console.log("cant pointerListenerAdd "+oDOM+", "+sEvent+", "+fCall);
 			return; // -- break --
 		}
 		switch(sEvent){
@@ -13594,7 +13597,7 @@ LGraphNode.prototype.executeAction = function(action)
 	}
 	LiteGraph.pointerListenerRemove = function(oDOM, sEvent, fCall, capture=false) {
 		if (!oDOM || !oDOM.removeEventListener || !sEvent || typeof fCall!=="function"){
-			console.log("cant pointerListenerRemove "+oDOM+", "+sEvent+", "+fCall);
+			//console.log("cant pointerListenerRemove "+oDOM+", "+sEvent+", "+fCall);
 			return; // -- break --
 		}
 		switch(sEvent){

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -3226,8 +3226,6 @@
 				if (!options.action_call) options.action_call = this.id+"_act_"+Math.floor(Math.random()*9999);
                 //pass the action name
                 var target_connection = node.inputs[link_info.target_slot];
-                //console.debug("ACTION: "+this.id+":"+this.order+" :: "+target_connection.name);
-                if (LiteGraph.refreshAncestorsOnActions) node.refreshAncestors({action: target_connection.name, param: param, options:options});
 				// wrap node.onAction(target_connection.name, param);
                 node.actionDo(target_connection.name, param, options);
             }

--- a/src/nodes/audio.js
+++ b/src/nodes/audio.js
@@ -997,7 +997,7 @@ LiteGraph.registerNodeType("audio/waveShaper", LGAudioWaveShaper);
         this.audionode = LGAudio.getAudioContext().createGain();
         this.audionode.gain.value = 0;
         this.addInput("in", "audio");
-        this.addInput("gate", "bool");
+        this.addInput("gate", "boolean");
         this.addOutput("out", "audio");
         this.gate = false;
     }

--- a/src/nodes/base.js
+++ b/src/nodes/base.js
@@ -724,9 +724,10 @@
     LiteGraph.registerNodeType("basic/const", ConstantNumber);
 
     function ConstantBoolean() {
-        this.addOutput("", "boolean");
+        this.addOutput("bool", "boolean");
         this.addProperty("value", true);
         this.widget = this.addWidget("toggle","value",true,"value");
+        this.serialize_widgets = true;
         this.widgets_up = true;
         this.size = [140, 30];
     }
@@ -753,7 +754,7 @@
     LiteGraph.registerNodeType("basic/boolean", ConstantBoolean);
 
     function ConstantString() {
-        this.addOutput("", "string");
+        this.addOutput("string", "string");
         this.addProperty("value", "");
         this.widget = this.addWidget("text","value","","value");  //link to property value
         this.widgets_up = true;
@@ -800,8 +801,8 @@
     LiteGraph.registerNodeType( "basic/object", ConstantObject );
 
     function ConstantFile() {
-        this.addInput("url", "");
-        this.addOutput("", "");
+        this.addInput("url", "string");
+        this.addOutput("file", "string");
         this.addProperty("url", "");
         this.addProperty("type", "text");
         this.widget = this.addWidget("text","url","","url");
@@ -899,7 +900,7 @@
 
 	//to store json objects
     function ConstantData() {
-        this.addOutput("", "");
+        this.addOutput("data", "object");
         this.addProperty("value", "");
         this.widget = this.addWidget("text","json","","value");
         this.widgets_up = true;
@@ -934,10 +935,10 @@
 
 	//to store json objects
     function ConstantArray() {
-        this._value = [];
-        this.addInput("", "");
-        this.addOutput("", "array");
-        this.addOutput("length", "number");
+		this._value = [];
+        this.addInput("json", "");
+        this.addOutput("arrayOut", "array");
+		this.addOutput("length", "number");
         this.addProperty("value", "[]");
         this.widget = this.addWidget("text","array",this.properties.value,"value");
         this.widgets_up = true;
@@ -974,7 +975,7 @@
 			for(var i = 0; i < v.length; ++i)
 				this._value[i] = v[i];
 		}
-		this.setOutputData(0, this._value );
+		this.setOutputData(0, this._value);
 		this.setOutputData(1, this._value ? ( this._value.length || 0) : 0 );
     };
 
@@ -988,7 +989,7 @@
         this.addInput("value", "");
         this.addOutput("arr", "array");
 		this.properties = { index: 0 };
-        this.widget = this.addWidget("number","i",this.properties.index,"index");
+        this.widget = this.addWidget("number","i",this.properties.index,"index",{precision: 0, step: 10, min: 0});
 	}
 
     SetArray.title = "Set Array";
@@ -1062,9 +1063,9 @@
     LiteGraph.registerNodeType("basic/table[][]", TableElement);
 
     function ObjectProperty() {
-        this.addInput("obj", "");
-        this.addOutput("", "");
-        this.addProperty("value", "");
+        this.addInput("obj", "object");
+        this.addOutput("property", 0);
+        this.addProperty("value", 0);
         this.widget = this.addWidget("text","prop.","",this.setValue.bind(this) );
         this.widgets_up = true;
         this.size = [140, 30];
@@ -1146,9 +1147,9 @@
 
 
     function MergeObjects() {
-        this.addInput("A", "");
-        this.addInput("B", "");
-        this.addOutput("", "");
+        this.addInput("A", "object");
+        this.addInput("B", "object");
+        this.addOutput("out", "object");
 		this._result = {};
 		var that = this;
 		this.addWidget("button","clear","",function(){
@@ -1396,21 +1397,27 @@
     Console.desc = "Show value inside the console";
 
     Console.prototype.onAction = function(action, param) {
+        // param is the action
+        var msg = this.getInputData(1); //getInputDataByName("msg");
+        //if (msg == null || typeof msg == "undefined") return;
+        if (!msg) msg = this.properties.msg;
+        if (!msg) msg = "Event: "+param; // msg is undefined if the slot is lost?
         if (action == "log") {
-            console.log(param);
+            console.log(msg);
         } else if (action == "warn") {
-            console.warn(param);
+            console.warn(msg);
         } else if (action == "error") {
-            console.error(param);
+            console.error(msg);
         }
     };
 
     Console.prototype.onExecute = function() {
-        var msg = this.getInputData(1);
-        if (msg !== null) {
+        var msg = this.getInputData(1); //getInputDataByName("msg");
+        if (!msg) msg = this.properties.msg;
+        if (msg != null && typeof msg != "undefined") {
             this.properties.msg = msg;
+            console.log(msg);
         }
-        console.log(msg);
     };
 
     Console.prototype.onGetInputs = function() {
@@ -1455,9 +1462,9 @@
     function NodeScript() {
         this.size = [60, 30];
         this.addProperty("onExecute", "return A;");
-        this.addInput("A", "");
-        this.addInput("B", "");
-        this.addOutput("out", "");
+        this.addInput("A", 0);
+        this.addInput("B", 0);
+        this.addOutput("out", 0);
 
         this._func = null;
         this.data = {};
@@ -1534,4 +1541,102 @@
     };
 
     LiteGraph.registerNodeType("basic/script", NodeScript);
+    
+    
+    function GenericCompare() {
+        this.addInput("A", 0);
+        this.addInput("B", 0);
+        this.addOutput("true", "boolean");
+        this.addOutput("false", "boolean");
+        this.addProperty("A", 1);
+        this.addProperty("B", 1);
+        this.addProperty("OP", "==", "enum", { values: GenericCompare.values });
+		this.addWidget("combo","Op.",this.properties.OP,{ property: "OP", values: GenericCompare.values } );
+
+        this.size = [80, 60];
+    }
+
+    GenericCompare.values = ["==", "!="]; //[">", "<", "==", "!=", "<=", ">=", "||", "&&" ];
+    GenericCompare["@OP"] = {
+        type: "enum",
+        title: "operation",
+        values: GenericCompare.values
+    };
+
+    GenericCompare.title = "Compare *";
+    GenericCompare.desc = "evaluates condition between A and B";
+
+    GenericCompare.prototype.getTitle = function() {
+        return "*A " + this.properties.OP + " *B";
+    };
+
+    GenericCompare.prototype.onExecute = function() {
+        var A = this.getInputData(0);
+        if (A === undefined) {
+            A = this.properties.A;
+        } else {
+            this.properties.A = A;
+        }
+
+        var B = this.getInputData(1);
+        if (B === undefined) {
+            B = this.properties.B;
+        } else {
+            this.properties.B = B;
+        }
+
+        var result = false;
+        if (typeof A == typeof B){
+            switch (this.properties.OP) {
+                case "==":
+                case "!=":
+                    // traverse both objects.. consider that this is not a true deep check! consider underscore or other library for thath :: _isEqual()
+                    result = true;
+                    switch(typeof A){
+                        case "object":
+                            var aProps = Object.getOwnPropertyNames(A);
+                            var bProps = Object.getOwnPropertyNames(B);
+                            if (aProps.length != bProps.length){
+                                result = false;
+                                break;
+                            }
+                            for (var i = 0; i < aProps.length; i++) {
+                                var propName = aProps[i];
+                                if (A[propName] !== B[propName]) {
+                                    result = false;
+                                    break;
+                                }
+                            }
+                        break;
+                        default:
+                            result = A == B;
+                    }
+                    if (this.properties.OP == "!=") result = !result;
+                    break;
+                /*case ">":
+                    result = A > B;
+                    break;
+                case "<":
+                    result = A < B;
+                    break;
+                case "<=":
+                    result = A <= B;
+                    break;
+                case ">=":
+                    result = A >= B;
+                    break;
+                case "||":
+                    result = A || B;
+                    break;
+                case "&&":
+                    result = A && B;
+                    break;*/
+            }
+        }
+        this.setOutputData(0, result);
+        this.setOutputData(1, !result);
+    };
+
+    LiteGraph.registerNodeType("basic/CompareValues", GenericCompare);
+    
 })(this);

--- a/src/nodes/events.js
+++ b/src/nodes/events.js
@@ -50,7 +50,8 @@
 
     //Sequencer for events
     function Sequencer() {
-        this.addInput("", LiteGraph.ACTION);
+        var that = this;
+		this.addInput("", LiteGraph.ACTION);
         this.addInput("", LiteGraph.ACTION);
         this.addInput("", LiteGraph.ACTION);
         this.addOutput("", LiteGraph.EVENT);

--- a/src/nodes/events.js
+++ b/src/nodes/events.js
@@ -11,7 +11,7 @@
     LogEvent.title = "Log Event";
     LogEvent.desc = "Log event in console";
 
-    LogEvent.prototype.onAction = function(action, param) {
+    LogEvent.prototype.onAction = function(action, param, options) {
         console.log(action, param);
     };
 
@@ -31,18 +31,18 @@
     TriggerEvent.title = "TriggerEvent";
     TriggerEvent.desc = "Triggers event if input evaluates to true";
 
-    TriggerEvent.prototype.onExecute = function(action, param) {
+    TriggerEvent.prototype.onExecute = function( param, options) {
 		var v = this.getInputData(0);
 		var changed = (v != this.prev);
 		if(this.prev === 0)
 			changed = false;
 		var must_resend = (changed && this.properties.only_on_change) || (!changed && !this.properties.only_on_change);
 		if(v && must_resend )
-	        this.triggerSlot(0, param);
+	        this.triggerSlot(0, param, null, options);
 		if(!v && must_resend)
-	        this.triggerSlot(2, param);
+	        this.triggerSlot(2, param, null, options);
 		if(changed)
-	        this.triggerSlot(1, param);
+	        this.triggerSlot(1, param, null, options);
 		this.prev = v;
     };
 
@@ -50,7 +50,6 @@
 
     //Sequencer for events
     function Sequencer() {
-		var that = this;
         this.addInput("", LiteGraph.ACTION);
         this.addInput("", LiteGraph.ACTION);
         this.addInput("", LiteGraph.ACTION);
@@ -72,10 +71,13 @@
         return "";
     };
 
-    Sequencer.prototype.onAction = function(action, param) {
+    Sequencer.prototype.onAction = function(action, param, options) {
         if (this.outputs) {
+            options = options || {};
             for (var i = 0; i < this.outputs.length; ++i) {
-                this.triggerSlot(i, param);
+				// CREATE A NEW ID FOR THE ACTION
+                options.action_call = options.action_call?options.action_call+"_seq_"+i:this.id+"_"+(action?action:"action")+"_seq_"+i+"_"+Math.floor(Math.random()*9999);
+                this.triggerSlot(i, param, null, options);
             }
         }
     };
@@ -97,7 +99,7 @@
     FilterEvent.title = "Filter Event";
     FilterEvent.desc = "Blocks events that do not match the filter";
 
-    FilterEvent.prototype.onAction = function(action, param) {
+    FilterEvent.prototype.onAction = function(action, param, options) {
         if (param == null) {
             return;
         }
@@ -120,7 +122,7 @@
             }
         }
 
-        this.triggerSlot(0, param);
+        this.triggerSlot(0, param, null, options);
     };
 
     LiteGraph.registerNodeType("events/filter", FilterEvent);
@@ -142,8 +144,9 @@
 		this._value = this.getInputData(1);
 	}
 
-    EventBranch.prototype.onAction = function(action, param) {
-		this.triggerSlot(this._value ? 0 : 1);
+    EventBranch.prototype.onAction = function(action, param, options) {
+        this._value = this.getInputData(1);
+		this.triggerSlot(this._value ? 0 : 1, param, null, options);
 	}
 
     LiteGraph.registerNodeType("events/branch", EventBranch);
@@ -155,6 +158,8 @@
         this.addInput("reset", LiteGraph.ACTION);
         this.addOutput("change", LiteGraph.EVENT);
         this.addOutput("num", "number");
+        this.addProperty("doCountExecution", false, "boolean", {name: "Count Executions"});
+        this.addWidget("toggle","Count Exec.",this.properties.doCountExecution,"doCountExecution");
         this.num = 0;
     }
 
@@ -168,7 +173,7 @@
         return this.title;
     };
 
-    EventCounter.prototype.onAction = function(action, param) {
+    EventCounter.prototype.onAction = function(action, param, options) {
         var v = this.num;
         if (action == "inc") {
             this.num += 1;
@@ -193,6 +198,9 @@
     };
 
     EventCounter.prototype.onExecute = function() {
+        if(this.properties.doCountExecution){
+            this.num += 1;
+        }
         this.setOutputData(1, this.num);
     };
 
@@ -211,16 +219,16 @@
     DelayEvent.title = "Delay";
     DelayEvent.desc = "Delays one event";
 
-    DelayEvent.prototype.onAction = function(action, param) {
+    DelayEvent.prototype.onAction = function(action, param, options) {
         var time = this.properties.time_in_ms;
         if (time <= 0) {
-            this.trigger(null, param);
+            this.trigger(null, param, options);
         } else {
             this._pending.push([time, param]);
         }
     };
 
-    DelayEvent.prototype.onExecute = function() {
+    DelayEvent.prototype.onExecute = function(param, options) {
         var dt = this.graph.elapsed_time * 1000; //in ms
 
         if (this.isInputConnected(1)) {
@@ -228,9 +236,9 @@
         }
 
         for (var i = 0; i < this._pending.length; ++i) {
-            var action = this._pending[i];
-            action[0] -= dt;
-            if (action[0] > 0) {
+            var actionPass = this._pending[i];
+            actionPass[0] -= dt;
+            if (actionPass[0] > 0) {
                 continue;
             }
 
@@ -239,7 +247,7 @@
             --i;
 
             //trigger
-            this.trigger(null, action[1]);
+            this.trigger(null, actionPass[1], options);
         }
     };
 
@@ -359,9 +367,9 @@
 
 
     function DataStore() {
-        this.addInput("data", "");
+        this.addInput("data", 0);
         this.addInput("assign", LiteGraph.ACTION);
-        this.addOutput("data", "");
+        this.addOutput("data", 0);
 		this._last_value = null;
 		this.properties = { data: null, serialize: true };
 		var that = this;
@@ -379,7 +387,7 @@
 		this.setOutputData(0, this.properties.data );
 	}
 
-    DataStore.prototype.onAction = function(action, param) {
+    DataStore.prototype.onAction = function(action, param, options) {
 		this.properties.data = this._last_value;
     };
 

--- a/src/nodes/interface.js
+++ b/src/nodes/interface.js
@@ -71,6 +71,7 @@
             local_pos[1] < this.size[1] - 2
         ) {
             this.clicked = true;
+            this.setOutputData(1, this.clicked);
             this.triggerSlot(0, this.properties.message);
             return true;
         }
@@ -672,7 +673,7 @@
             typeof v == "number" ? v.toFixed(this.properties["decimals"]) : v;
 
         if (typeof this.str == "string") {
-            var lines = this.str.split("\\n");
+            var lines = this.str.replace(/[\r\n]/g, "\\n").split("\\n");
             for (var i=0; i < lines.length; i++) {
                 ctx.fillText(
                     lines[i],

--- a/src/nodes/logic.js
+++ b/src/nodes/logic.js
@@ -82,4 +82,120 @@
     };
 
     LiteGraph.registerNodeType("logic/sequence", Sequence);
+	
+    
+    function logicAnd(){
+        this.properties = { };
+        this.addInput("a", "boolean");
+        this.addInput("b", "boolean");
+        this.addOutput("out", "boolean");
+    }
+    logicAnd.title = "AND";
+    logicAnd.desc = "Return true if all inputs are true";
+    logicAnd.prototype.onExecute = function() {
+        ret = true;
+        for (inX in this.inputs){
+            if (!this.getInputData(inX)){
+                ret = false;
+                break;
+            }
+        }
+        this.setOutputData(0, ret);
+    };
+    logicAnd.prototype.onGetInputs = function() {
+        return [
+            ["and", "boolean"]
+        ];
+    };
+    LiteGraph.registerNodeType("logic/AND", logicAnd);
+    
+    
+    function logicOr(){
+        this.properties = { };
+        this.addInput("a", "boolean");
+        this.addInput("b", "boolean");
+        this.addOutput("out", "boolean");
+    }
+    logicOr.title = "OR";
+    logicOr.desc = "Return true if at least one input is true";
+    logicOr.prototype.onExecute = function() {
+        ret = false;
+        for (inX in this.inputs){
+            if (this.getInputData(inX)){
+                ret = true;
+                break;
+            }
+        }
+        this.setOutputData(0, ret);
+    };
+    logicOr.prototype.onGetInputs = function() {
+        return [
+            ["or", "boolean"]
+        ];
+    };
+    LiteGraph.registerNodeType("logic/OR", logicOr);
+    
+    
+    function logicNot(){
+        this.properties = { };
+        this.addInput("in", "boolean");
+        this.addOutput("out", "boolean");
+    }
+    logicNot.title = "NOT";
+    logicNot.desc = "Return the logical negation";
+    logicNot.prototype.onExecute = function() {
+        var ret = !this.getInputData(0);
+        this.setOutputData(0, ret);
+    };
+    LiteGraph.registerNodeType("logic/NOT", logicNot);
+    
+    
+    function logicCompare(){
+        this.properties = { };
+        this.addInput("a", "boolean");
+        this.addInput("b", "boolean");
+        this.addOutput("out", "boolean");
+    }
+    logicCompare.title = "bool == bool";
+    logicCompare.desc = "Compare for logical equality";
+    logicCompare.prototype.onExecute = function() {
+        last = null;
+        ret = true;
+        for (inX in this.inputs){
+            if (last === null) last = this.getInputData(inX);
+            else
+                if (last != this.getInputData(inX)){
+                    ret = false;
+                    break;
+                }
+        }
+        this.setOutputData(0, ret);
+    };
+    logicCompare.prototype.onGetInputs = function() {
+        return [
+            ["bool", "boolean"]
+        ];
+    };
+    LiteGraph.registerNodeType("logic/CompareBool", logicCompare);
+    
+    
+    function logicBranch(){
+        this.properties = { };
+        this.addInput("onTrigger", LiteGraph.ACTION);
+        this.addInput("condition", "boolean");
+        this.addOutput("true", LiteGraph.EVENT);
+        this.addOutput("false", LiteGraph.EVENT);
+        this.mode = LiteGraph.ON_TRIGGER;
+    }
+    logicBranch.title = "Branch";
+    logicBranch.desc = "Branch execution on condition";
+    logicBranch.prototype.onExecute = function(param, options) {
+        var condtition = this.getInputData(1);
+        if (condtition){
+            this.triggerSlot(0);
+        }else{
+            this.triggerSlot(1);
+        }
+    };
+    LiteGraph.registerNodeType("logic/IF", logicBranch);
 })(this);

--- a/src/nodes/math.js
+++ b/src/nodes/math.js
@@ -3,8 +3,8 @@
 
     //Converter
     function Converter() {
-        this.addInput("in", "");
-	this.addOutput("out");
+        this.addInput("in", 0);
+		this.addOutput("out", 0);
         this.size = [80, 30];
     }
 
@@ -925,10 +925,10 @@
 
 
     function MathBranch() {
-        this.addInput("in", "");
+        this.addInput("in", 0);
         this.addInput("cond", "boolean");
-        this.addOutput("true", "");
-        this.addOutput("false", "");
+        this.addOutput("true", 0);
+        this.addOutput("false", 0);
         this.size = [80, 60];
     }
 

--- a/src/nodes/others.js
+++ b/src/nodes/others.js
@@ -1,0 +1,1 @@
+// extra generic nodes

--- a/src/nodes/others.js
+++ b/src/nodes/others.js
@@ -1,1 +1,37 @@
-// extra generic nodes
+(function(global) {
+    var LiteGraph = global.LiteGraph;
+    
+    /* in types :: run in console :: var s=""; LiteGraph.slot_types_in.forEach(function(el){s+=el+"\n";}); console.log(s); */
+    
+    if(typeof LiteGraph.slot_types_default_in == "undefined") LiteGraph.slot_types_default_in = {};
+    LiteGraph.slot_types_default_in["_event_"] = "widget/button";
+    LiteGraph.slot_types_default_in["array"] = "basic/array";
+    LiteGraph.slot_types_default_in["boolean"] = "basic/boolean";
+    LiteGraph.slot_types_default_in["number"] = "widget/number";
+    LiteGraph.slot_types_default_in["object"] = "basic/data";
+    LiteGraph.slot_types_default_in["string"] = ["basic/string","string/concatenate"];
+    LiteGraph.slot_types_default_in["vec2"] = "math3d/xy-to-vec2";
+    LiteGraph.slot_types_default_in["vec3"] = "math3d/xyz-to-vec3";
+    LiteGraph.slot_types_default_in["vec4"] = "math3d/xyzw-to-vec4";
+    
+    /* out types :: run in console :: var s=""; LiteGraph.slot_types_out.forEach(function(el){s+=el+"\n";}); console.log(s); */
+    if(typeof LiteGraph.slot_types_default_out == "undefined") LiteGraph.slot_types_default_out = {};
+    LiteGraph.slot_types_default_out["_event_"] = ["logic/IF","events/sequence","events/log","events/counter"];
+    LiteGraph.slot_types_default_out["array"] = ["basic/watch","basic/set_array","basic/array[]"];
+    LiteGraph.slot_types_default_out["boolean"] = ["logic/IF","basic/watch","math/branch","math/gate"];
+    LiteGraph.slot_types_default_out["number"] = ["basic/watch"
+												  ,{node:"math/operation",properties:{OP:"*"},title:"A*B"}
+												  ,{node:"math/operation",properties:{OP:"/"},title:"A/B"}
+												  ,{node:"math/operation",properties:{OP:"+"},title:"A+B"}
+												  ,{node:"math/operation",properties:{OP:"-"},title:"A-B"}
+												  ,{node:"math/compare",outputs:[["A==B", "boolean"]],title:"A==B"}
+												  ,{node:"math/compare",outputs:[["A>B", "boolean"]],title:"A>B"}
+												  ,{node:"math/compare",outputs:[["A<B", "boolean"]],title:"A<B"}
+												];
+    LiteGraph.slot_types_default_out["object"] = ["basic/object_property","basic/keys",["string/toString","basic/watch"]];
+    LiteGraph.slot_types_default_out["string"] = ["basic/watch","string/compare","string/concatenate","string/contains"];
+    LiteGraph.slot_types_default_out["vec2"] = "math3d/vec2-to-xy";
+    LiteGraph.slot_types_default_out["vec3"] = "math3d/vec3-to-xyz";
+    LiteGraph.slot_types_default_out["vec4"] = "math3d/vec4-to-xyzw";
+    
+})(this);

--- a/src/nodes/others.js
+++ b/src/nodes/others.js
@@ -3,7 +3,7 @@
     
     /* in types :: run in console :: var s=""; LiteGraph.slot_types_in.forEach(function(el){s+=el+"\n";}); console.log(s); */
     
-    if(typeof LiteGraph.slot_types_default_in == "undefined") LiteGraph.slot_types_default_in = {};
+    if(typeof LiteGraph.slot_types_default_in == "undefined") LiteGraph.slot_types_default_in = {}; //[];
     LiteGraph.slot_types_default_in["_event_"] = "widget/button";
     LiteGraph.slot_types_default_in["array"] = "basic/array";
     LiteGraph.slot_types_default_in["boolean"] = "basic/boolean";
@@ -16,7 +16,7 @@
     
     /* out types :: run in console :: var s=""; LiteGraph.slot_types_out.forEach(function(el){s+=el+"\n";}); console.log(s); */
     if(typeof LiteGraph.slot_types_default_out == "undefined") LiteGraph.slot_types_default_out = {};
-    LiteGraph.slot_types_default_out["_event_"] = ["logic/IF","events/sequence","events/log","events/counter"];
+    LiteGraph.slot_types_default_out["_event_"] = ["logic/IF","events/sequencer","events/log","events/counter"];
     LiteGraph.slot_types_default_out["array"] = ["basic/watch","basic/set_array","basic/array[]"];
     LiteGraph.slot_types_default_out["boolean"] = ["logic/IF","basic/watch","math/branch","math/gate"];
     LiteGraph.slot_types_default_out["number"] = ["basic/watch"

--- a/src/nodes/strings.js
+++ b/src/nodes/strings.js
@@ -17,7 +17,7 @@
         return String(a);
     }
 
-    LiteGraph.wrapFunctionAsNode("string/toString", toString, [""], "String");
+    LiteGraph.wrapFunctionAsNode("string/toString", toString, [""], "string");
 
     function compare(a, b) {
         return a == b;
@@ -85,8 +85,10 @@
 		else if( str.constructor === Array )
 		{
 			var r = [];
-			for(var i = 0; i < str.length; ++i)
-				r[i] = str[i].split(separator || " ");
+			for(var i = 0; i < str.length; ++i){
+                if (typeof str[i] == "string")
+				    r[i] = str[i].split(separator || " ");
+            }
 			return r;
 		}
         return null;


### PR DESCRIPTION
This is a pack of many of the integrations I had made.
It was intended as a small pack.. some changes are tied together and others are quite useful and unoffensive, the result is a big change in the sense of portions of code it touches, I think for the good anyway.
Let alone minor changes, new behaviors can be enabled and disabled by properties and everything should be retrocompatibile.

Let's check the changes with some good graphs we have to ensure all the past and new functionaries are stable.


::features::

- improved auto-connect
- allow connecting from IN to OUT (drag an IN slot to create a link to OUT slots)
- dim (opacity) uncompatible slots while creating a link
- filter in the searchbox for types (slotsIn, slotsOut), autofilter when chaining
- drag-shift a slot to search and connect a new node
- wheel-click a slot to create a default node for that slot_type
- add a quick node creation based on slot_type when releasing a link
- code widget re-enabled
- properties panel improvements
- paste will use mouse coordinates
- additional shape GRID_SHAPE intended for slot arrays
- NODE_MODES_COLORS array of colors based on the node modes
- canvas `default_connection_color_byType[Off]` allows custom colors type based


::settings::

`node_box_coloured_by_mode`: false, // [true!] nodebox colored on node mode, visual feedback
`node_box_coloured_when_on`: false, // [true!] this make the nodes box (top left circle) coloured when triggered (execute/action), visual feedback

`dialog_close_on_mouse_leave`: true, // better true if not touch device
`dialog_close_on_mouse_leave_delay`: 500,

`shift_click_do_break_link_from`: false, // [false!] prefer false if results too easy to break links - TODO custom keys
`click_do_break_link_to`: false, // [false!] prefer false, way too easy to break links

`search_hide_on_mouse_leave`: true, // better true if not touch device
`search_filter_enabled`: true, // [true!] enable filtering slots type in the search widget, !requires auto_load_slot_types
`search_show_all_on_open`: true, // [true!] opens the results list when opening the search widget

`auto_load_slot_types`: true, // [if want false, use true, run, get vars values to be statically set, than disable] nodes types and nodeclass association with node types need to be calculated, if dont want this, calculate once and set `registered_slot_[in/out]_types` and `slot_types_[in/out]`
_this will create (without adding it) a node for each class when they are registered. This allows for slots checking. Could raise errors in case some node miss something: somehow nice._


`alt_drag_do_clone_nodes`: false, // [true!] very handy, ALT click to clone and drag the new node

`do_add_triggers_slots`: false, // [true!] will create and connect event slots when using action/events connections, !WILL CHANGE node mode when using onTrigger (enable mode colors), onExecuted does not need this

`allowMultiOutputForEvents`: true, // [false!] being events, it is strongly recommended to use them sequentially, one by one



::more::

- `find(Input/Output)Slot` functions can return the object instead
- `connectByType`- allow connecting a node slot to a target node using an auto-slot mode that looks for the right types
- `onNodeCreated `- new callback
- `addOnTriggerInput`, `addOnExecutedOutput`- creates action slots (triggerIn, executedOut) when needed (changing mode, dragging events onto the node)
- `doExecute` and `doAction` - wraps the onExecute and onAction node functions with helpers and checks
- `onAfterExecuteNode` - new callback
- `onBeforeConnectInput` - new callback, can change slot while connecting (or create a new one)
- `onConnectOutput` - new callback, similar to onConnectInput
- `onNodeInputAdd, onNodeOutputAdd` - new callbacks
- `isOverNodeOutput` - similar to isOverNodeInput
- helpers `findInput, findOutput, findInputSlotFree, findOutputSlotFree, findSlotByType`
- showConnectionMenu will show the "Add menu" while dragging, to connect after creation
- ESC will close panels


::minor fixes & changes::
....
