### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contribution Rules
 There are some simple rules that everyone should follow:
 
-### Do not commit files from bulid folder
+### Do not commit files from build folder
 > I usually have horrible merge conflicts when I upload the build version that take me too much time to solve, but I want to keep the build version in the repo, so I guess it would be better if only one of us does the built, which would be me.
 > https://github.com/jagenjo/litegraph.js/pull/155#issuecomment-656602861
 Those files will be updated by owner.

--- a/guides/README.md
+++ b/guides/README.md
@@ -44,7 +44,7 @@ MyAddNode.prototype.onExecute = function()
   var B = this.getInputData(1);
   if( B === undefined )
     B = 0;
-  //assing data to otputs
+  //assing data to outputs
   this.setOutputData( 0, A + B );
 }
 
@@ -177,7 +177,7 @@ You can add widgets inside the node to edit text, values, etc.
 
 To do so you must create them in the constructor by calling ```node.addWidget```, the returned value is the object containing all the info about the widget, it is handy to store it in case you want to change the value later from code.
 
-The sintax is:
+The syntax is:
 
 ```js
 function MyNodeType()
@@ -188,7 +188,7 @@ function MyNodeType()
 
 This is the list of supported widgets:
 * **"number"** to change a value of a number, the syntax is ```this.addWidget("number","Number", current_value, callback, { min: 0, max: 100, step: 1} );```
-* **"slider"** to change a number by draging the mouse, the syntax is the same as number.
+* **"slider"** to change a number by dragging the mouse, the syntax is the same as number.
 * **"combo"** to select between multiple choices, the syntax is:
 
   ```this.addWidget("combo","Combo", "red", callback, { values:["red","green","blue"]} );```

--- a/src/nodes/midi.js
+++ b/src/nodes/midi.js
@@ -196,7 +196,7 @@
                 return MIDIEvent.TIMETICK;
                 break;
             default:
-                return Number(str); //asume its a hex code
+                return Number(str); //assume its a hex code
         }
     };
 


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.md
- guides/README.md
- src/nodes/midi.js

Fixes:
- Should read `syntax` rather than `sintax`.
- Should read `outputs` rather than `otputs`.
- Should read `dragging` rather than `draging`.
- Should read `build` rather than `bulid`.
- Should read `assume` rather than `asume`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md