### PR TITLE
Add generic font fallbacks & prune some unused styles

### DIFF
--- a/css/litegraph-editor.css
+++ b/css/litegraph-editor.css
@@ -11,29 +11,6 @@
     position: relative;
 }
 
-.litegraph-editor h1 {
-    font-family: "Metro Light", Tahoma;
-    color: #ddd;
-    font-size: 28px;
-    padding-left: 10px;
-    /*text-shadow: 0 1px 1px #333, 0 -1px 1px #777;*/
-    margin: 0;
-    font-weight: normal;
-}
-
-.litegraph-editor h1 span {
-    font-family: "Arial";
-    font-size: 14px;
-    font-weight: normal;
-    color: #aaa;
-}
-
-.litegraph-editor h2 {
-    font-family: "Metro Light";
-    padding: 5px;
-    margin-left: 10px;
-}
-
 .litegraph-editor * {
     box-sizing: border-box;
     -moz-box-sizing: border-box;

--- a/css/litegraph-editor.css
+++ b/css/litegraph-editor.css
@@ -6,7 +6,7 @@
 
     background-color: #333;
     color: #eee;
-    font: 14px Tahoma;
+    font: 14px "Tahoma", sans-serif;
 
     position: relative;
 }
@@ -62,7 +62,7 @@
     position: absolute;
     top: 2px;
     right: 2px;
-    font-family: "Tahoma";
+    font-family: "Tahoma", sans-serif;
     font-size: 14px;
     color: #aaa;
     cursor: pointer;
@@ -137,7 +137,7 @@
 /* METER *********************/
 
 .litegraph-editor .loadmeter {
-    font-family: "Tahoma";
+    font-family: "Tahoma", sans-serif;
     color: #aaa;
     font-size: 12px;
     border-radius: 2px;
@@ -175,7 +175,7 @@
 	width: 100%;
 	background-color: black;
 	padding: 4px;
-	font: 16px monospace;
+	font: 16px "Consolas", monospace;
 	overflow: auto;
 	resize: none;
 	outline: none;

--- a/css/litegraph.css
+++ b/css/litegraph.css
@@ -6,7 +6,7 @@
     -moz-user-select: none;
     -webkit-user-select: none;
 	outline: none;
-    font-family: Tahoma, sans-serif;
+    font-family: "Tahoma", sans-serif;
 }
 
 .lgraphcanvas * {
@@ -14,7 +14,7 @@
 }
 
 .litegraph.litecontextmenu {
-    font-family: Tahoma, sans-serif;
+    font-family: "Tahoma", sans-serif;
     position: fixed;
     top: 100px;
     left: 100px;
@@ -50,7 +50,7 @@
 }
 
 .litegraph .litemenubar ul {
-    font-family: Tahoma, sans-serif;
+    font-family: "Tahoma", sans-serif;
     margin: 0;
     padding: 0;
 }
@@ -168,7 +168,7 @@
 }
 
 .litegraph.litesearchbox {
-    font-family: Tahoma, sans-serif;
+    font-family: "Tahoma", sans-serif;
     position: absolute;
     background-color: rgba(0, 0, 0, 0.5);
     padding-top: 4px;
@@ -200,7 +200,7 @@
 }
 
 .litegraph.lite-search-item {
-    font-family: Tahoma, sans-serif;
+    font-family: "Tahoma", sans-serif;
     background-color: rgba(0, 0, 0, 0.5);
     color: white;
     padding-top: 2px;
@@ -284,7 +284,7 @@
 .litegraph .dialog .dialog-footer { height: 50px; padding: 10px; border-top: 1px solid #1a1a1a;}
 
 .litegraph .dialog .dialog-header .dialog-title {
-    font: 20px "Arial";
+    font: 20px "Arial", sans-serif;
     margin: 4px;
     padding: 4px 10px;
     display: inline-block;

--- a/editor/style.css
+++ b/editor/style.css
@@ -8,7 +8,7 @@ html,body {
 body {
 	background-color: #333;
 	color: #EEE;
-	font: 14px Tahoma;
+	font: 14px "Tahoma", sans-serif;
 }
 
 #main {
@@ -123,7 +123,7 @@ label {
 	/*border-radius: 4px;*/
 	padding: 2px;
 	/*box-shadow: inset 0 0 3px #333; */
-	font-family: Verdana;
+	font-family: "Verdana", sans-serif;
 	width: 250px;
 }
 

--- a/editor/style.css
+++ b/editor/style.css
@@ -11,14 +11,6 @@ body {
 	font: 14px Tahoma;
 }
 
-h1 {
-	font-family: "Metro Light",Tahoma;
-}
-
-h2 {
-	font-family: "Metro Light";
-}
-
 #main {
 	width: 100%;
 	height: 100%;


### PR DESCRIPTION
- added generic fallback (`sans-serif`) to every font specification
- enclosed all explicit font names in quotes for consistency and visual difference
- `h1` and `h2` elements don't seem to be used anywhere outside of the docs, so I pruned them from litegraph-editor.css and editor/style.css

This makes the UI look better on Linux which doesn't have fonts like Tahoma and Verdana. Personally, I would go further and re-do all of the font assignment based on Boostrap 5's [system font stack](https://getbootstrap.com/docs/5.1/content/reboot/#native-font-stack), to quote, "for optimum text rendering on every device and OS".
But it's be up to the maintainer to say whether this is desirable :)

@atlasan might want to take a look at this as well, since I see they've been editing the CSS