### PR TITLE
Add setProperty to typescript definition

### DIFF
--- a/src/litegraph.d.ts
+++ b/src/litegraph.d.ts
@@ -666,6 +666,8 @@ export declare class LGraphNode {
     toString(): string;
     /** get the title string */
     getTitle(): string;
+    /** sets the value of a property */
+    setProperty(name: string, value: any): void;
     /** sets the output data */
     setOutputData(slot: number, data: any): void;
     /** sets the output data */


### PR DESCRIPTION
The typescript definition for LGraphNode is missing the `setProperty` method that is already implemented in the library. This PR resolves it