### PR TITLE
Fix NodeScript description

### DIFF
--- a/src/nodes/base.js
+++ b/src/nodes/base.js
@@ -1480,7 +1480,7 @@
     };
 
     NodeScript.title = "Script";
-    NodeScript.desc = "executes a code (max 100 characters)";
+    NodeScript.desc = "executes a code (max 256 characters)";
 
     NodeScript.widgets_info = {
         onExecute: { type: "code" }


### PR DESCRIPTION
Hi,

this changes the description of NodeScript nodes to contain the correct number of allowed characters.
The node description and logic did not match before.

-ClaasJG