### PR TITLE
Add the ability to select multi nodes/blocks without pressing extra keys (shift/Ctrl)

### DIFF
--- a/src/litegraph.d.ts
+++ b/src/litegraph.d.ts
@@ -1142,6 +1142,8 @@ export declare class LGraphCanvas {
     allow_interaction: boolean;
     /** allows to change a connection with having to redo it again */
     allow_reconnect_links: boolean;
+    /** allow selecting multi nodes without pressing extra keys */
+    multi_select: boolean;
     /** No effect */
     allow_searchbox: boolean;
     always_render_background: boolean;

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -6053,9 +6053,7 @@ LGraphNode.prototype.executeAction = function(action)
 							this.graph.beforeChange();
                             this.node_dragged = node;
                         }
-                        if (!this.selected_nodes[node.id]) {
-                            this.processNodeSelected(node, e);
-                        }
+                        this.processNodeSelected(node, e);
                     }
 
                     this.dirty_canvas = true;
@@ -7316,6 +7314,7 @@ LGraphNode.prototype.executeAction = function(action)
         for (var i in nodes) {
             var node = nodes[i];
             if (node.is_selected) {
+                this.deselectNode(node);
                 continue;
             }
 

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -5202,6 +5202,7 @@ LGraphNode.prototype.executeAction = function(action)
         this.allow_dragcanvas = true;
         this.allow_dragnodes = true;
         this.allow_interaction = true; //allow to control widgets, buttons, collapse, etc
+        this.multi_select = false; //allow selecting multi nodes without pressing extra keys
         this.allow_searchbox = true;
         this.allow_reconnect_links = true; //allows to change a connection with having to redo it again
 		this.align_to_grid = false; //snap to grid
@@ -7279,7 +7280,7 @@ LGraphNode.prototype.executeAction = function(action)
     };
 
     LGraphCanvas.prototype.processNodeSelected = function(node, e) {
-        this.selectNode(node, e && (e.shiftKey||e.ctrlKey));
+        this.selectNode(node, e && (e.shiftKey || e.ctrlKey || this.multi_select));
         if (this.onNodeSelected) {
             this.onNodeSelected(node);
         }


### PR DESCRIPTION
The feature is helpful, especially for touch devices where it would be hard to hold the Shift/Ctrl keys while selecting blocks. Only put a button on your app that turns on the multi-select mode, and there is no need to press any other keys while selecting blocks.