### PR TITLE
docs: Fix a few typos

### DIFF
--- a/editor/js/defaults.js
+++ b/editor/js/defaults.js
@@ -25,7 +25,7 @@ LiteGraph.slot_types_out = []; // slot types OUT*/
 
 LiteGraph.alt_drag_do_clone_nodes = true; // [true!] very handy; ALT click to clone and drag the new node
 LiteGraph.do_add_triggers_slots = true; // [true!] will create and connect event slots when using action/events connections; !WILL CHANGE node mode when using onTrigger (enable mode colors); onExecuted does not need this
-LiteGraph.allow_multi_output_for_events = false; // [false!] being events; it is strongly reccomended to use them sequentually; one by one
+LiteGraph.allow_multi_output_for_events = false; // [false!] being events; it is strongly reccomended to use them sequentially; one by one
 LiteGraph.middle_click_slot_add_default_node = true;  //[true!] allows to create and connect a ndoe clicking with the third button (wheel)
 LiteGraph.release_link_on_empty_shows_menu = true; //[true!] dragging a link to empty space will open a menu, add from list, search or defaults
 LiteGraph.pointerevents_method = "mouse"; // "mouse"|"pointer" use mouse for retrocompatibility issues? (none found @ now)

--- a/editor/js/defaults_mobile.js
+++ b/editor/js/defaults_mobile.js
@@ -25,7 +25,7 @@ LiteGraph.slot_types_out = []; // slot types OUT*/
 
 LiteGraph.alt_drag_do_clone_nodes = true; // [true!] very handy; ALT click to clone and drag the new node
 LiteGraph.do_add_triggers_slots = true; // [true!] will create and connect event slots when using action/events connections; !WILL CHANGE node mode when using onTrigger (enable mode colors); onExecuted does not need this
-LiteGraph.allow_multi_output_for_events = false; // [false!] being events; it is strongly reccomended to use them sequentually; one by one
+LiteGraph.allow_multi_output_for_events = false; // [false!] being events; it is strongly reccomended to use them sequentially; one by one
 LiteGraph.middle_click_slot_add_default_node = true;  //[true!] allows to create and connect a ndoe clicking with the third button (wheel)
 LiteGraph.release_link_on_empty_shows_menu = true; //[true!] dragging a link to empty space will open a menu, add from list, search or defaults
 LiteGraph.pointerevents_method = "pointer"; // "mouse"|"pointer" use mouse for retrocompatibility issues? (none found @ now)

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -124,14 +124,14 @@
         registered_slot_out_types: {}, // slot types for nodeclass
         slot_types_in: [], // slot types IN
         slot_types_out: [], // slot types OUT
-        slot_types_default_in: [], // specify for each IN slot type a(/many) deafult node(s), use single string, array, or object (with node, title, parameters, ..) like for search
-		slot_types_default_out: [], // specify for each OUT slot type a(/many) deafult node(s), use single string, array, or object (with node, title, parameters, ..) like for search
+        slot_types_default_in: [], // specify for each IN slot type a(/many) default node(s), use single string, array, or object (with node, title, parameters, ..) like for search
+		slot_types_default_out: [], // specify for each OUT slot type a(/many) default node(s), use single string, array, or object (with node, title, parameters, ..) like for search
 		
 		alt_drag_do_clone_nodes: false, // [true!] very handy, ALT click to clone and drag the new node
 
 		do_add_triggers_slots: false, // [true!] will create and connect event slots when using action/events connections, !WILL CHANGE node mode when using onTrigger (enable mode colors), onExecuted does not need this
 		
-		allow_multi_output_for_events: true, // [false!] being events, it is strongly reccomended to use them sequentually, one by one
+		allow_multi_output_for_events: true, // [false!] being events, it is strongly reccomended to use them sequentially, one by one
 
 		middle_click_slot_add_default_node: false, //[true!] allows to create and connect a ndoe clicking with the third button (wheel)
 		
@@ -5437,7 +5437,7 @@ LGraphNode.prototype.executeAction = function(action)
     };
 
     /**
-     * returns the visualy active graph (in case there are more in the stack)
+     * returns the visually active graph (in case there are more in the stack)
      * @method getCurrentGraph
      * @return {LGraph} the active graph
      */

--- a/src/nodes/geometry.js
+++ b/src/nodes/geometry.js
@@ -363,7 +363,7 @@
 			return -1;
 		if(l == 1)
 			return 0;
-		//dichotimic search
+		//dichotomic search
 		while (imax >= imin)
 		{
 			imid = ((imax + imin)*0.5)|0;

--- a/src/nodes/gltextures.js
+++ b/src/nodes/gltextures.js
@@ -5338,7 +5338,7 @@ void main(void){\n\
 				}
 				gl.finish2D();
 			});
-		else //rendering to offscren canvas and uploading to texture
+		else //rendering to offscreen canvas and uploading to texture
 		{
 			if(properties.clear)
 				ctx.clearRect(0,0,canvas.width,canvas.height);


### PR DESCRIPTION
There are small typos in:
- editor/js/defaults.js
- editor/js/defaults_mobile.js
- src/litegraph.js
- src/nodes/geometry.js
- src/nodes/gltextures.js

Fixes:
- Should read `sequentially` rather than `sequentually`.
- Should read `default` rather than `deafult`.
- Should read `visually` rather than `visualy`.
- Should read `offscreen` rather than `offscren`.
- Should read `dichotomic` rather than `dichotimic`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md