### PR TITLE
Fix panel not defined.

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -12298,7 +12298,7 @@ LGraphNode.prototype.executeAction = function(action)
 		var ref_window = this.getCanvasWindow();
         var that = this;
 		var graphcanvas = this;
-		panel = this.createPanel(node.title || "",{
+		var panel = this.createPanel(node.title || "",{
                                                     closable: true
                                                     ,window: ref_window
                                                     ,onOpen: function(){


### PR DESCRIPTION
An exception was triggered when dblclicking on a node, as the variable panel was not defined. This should fix it.