### PR TITLE
organize reciving input  from prompt dialog

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -9985,8 +9985,7 @@ LGraphNode.prototype.executeAction = function(action)
 						var delta = x < 40 ? -1 : x > widget_width - 40 ? 1 : 0;
 						if (event.click_time < 200 && delta == 0) {
 							this.prompt("Value",w.value,function(v) {
-									this.value = Number(v);
-									inner_value_change(this, this.value);
+                                inner_value_change(this, this.value);
 								}.bind(w),
 								event);
 						}
@@ -10013,7 +10012,6 @@ LGraphNode.prototype.executeAction = function(action)
 				case "text":
 					if (event.type == LiteGraph.pointerevents_method+"down") {
 						this.prompt("Value",w.value,function(v) {
-								this.value = v;
 								inner_value_change(this, v);
 							}.bind(w),
 							event,w.options ? w.options.multiline : false );
@@ -10038,6 +10036,9 @@ LGraphNode.prototype.executeAction = function(action)
         }//end for
 
         function inner_value_change(widget, value) {
+            if(widget.type == "number"){
+                value = Number(value);
+            }
             widget.value = value;
             if ( widget.options && widget.options.property && node.properties[widget.options.property] !== undefined ) {
                 node.setProperty( widget.options.property, value );


### PR DESCRIPTION
Make that inner_value_change function will be the one to check if widget is number and parse the data to number then 

this allows others to have a chance to intercept the input coming from the prompt and do something on it 

as currently, there is no way to know the widget type and do something on the input based on that , 
so I did these changes to make that possible 

Kindly accept my pull request , and also kindly allow me to express my gratitude for your great tool 

Thanks. 