### PR TITLE
Fix CTRL-C, CTRL-V not working on remapped keyboards.

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -7003,7 +7003,7 @@ LGraphNode.prototype.executeAction = function(action)
                 block_default = true;
             }
 
-            if (e.code == "KeyC" && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
+            if ((e.keyCode === 67) && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
                 //copy
                 if (this.selected_nodes) {
                     this.copyToClipboard();
@@ -7011,7 +7011,7 @@ LGraphNode.prototype.executeAction = function(action)
                 }
             }
 
-            if (e.code == "KeyV" && (e.metaKey || e.ctrlKey)) {
+            if ((e.keyCode === 86) && (e.metaKey || e.ctrlKey)) {
                 //paste
                 this.pasteFromClipboard(e.shiftKey);
             }


### PR DESCRIPTION
I use a different layout on my keyboard than the physical one and e.code returns the physical key and not the remapped key.