### PR TITLE
Add support for decimal evaluation

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -10034,7 +10034,7 @@ LGraphNode.prototype.executeAction = function(action)
 						if (event.click_time < 200 && delta == 0) {
 							this.prompt("Value",w.value,function(v) {
 									// check if v is a valid equation or a number
-									  if (/^[0-9+\-*/()\s]+$/.test(v)) {
+									  if (/^[0-9+\-*/()\s]+|\d+\.\d+$/.test(v)) {
 										try {//solve the equation if possible
 									    		v = eval(v);
 										} catch (e) { }


### PR DESCRIPTION
Extends the regex to allow number[dot]number in the evaluation, e.g. `(8.25 * 3.25) / 2.5 + 1.275` is now supported
I've added `\d\.\d` explicitly rather than just adding it to the range as it seemed safer.