### PR TITLE
Simplify the allow_interaction override to only use node flags

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -233,8 +233,7 @@ LGraphCanvas is the class in charge of rendering/interaction with the nodes insi
 ## LGraphCanvas settings
 There are graph canvas settings that could be defined or modified to change behaviour:
 
-* **allow_interaction**: when set to `false` disable interaction with the canvas
-* **drag_mode**: when set to `true` and `allow_interaction` is `false`, allow individual nodes with `flags.allow_interaction` set to `true` to be interacted with
+* **allow_interaction**: when set to `false` disable interaction with the canvas (`flags.allow_interaction` on node can be used to override graph canvas setting)
 
 ### Canvas Shortcuts
 * Space - Holding space key while moving the cursor moves the canvas around. It works when holding the mouse button down so it is easier to connect different nodes when the canvas gets too large.

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -5214,7 +5214,7 @@ LGraphNode.prototype.executeAction = function(action)
         this.allow_reconnect_links = true; //allows to change a connection with having to redo it again
 		this.align_to_grid = false; //snap to grid
 
-        this.drag_mode = false; // allow dragging when interactions are disabled
+        this.drag_mode = false;
         this.dragging_rectangle = null;
 
         this.filter = null; //allows to filter to only accept some type of nodes in a graph
@@ -5865,7 +5865,7 @@ LGraphNode.prototype.executeAction = function(action)
 
             //when clicked on top of a node
             //and it is not interactive
-            if (node && (this.allow_interaction || (!this.allow_interaction && node.flags.allow_interaction)) && !skip_action && !this.read_only) {
+            if (node && (this.allow_interaction || node.flags.allow_interaction) && !skip_action && !this.read_only) {
                 if (!this.live_mode && !node.flags.pinned) {
                     this.bringToFront(node);
                 } //if it wasn't selected?
@@ -6299,6 +6299,9 @@ LGraphNode.prototype.executeAction = function(action)
             this.dirty_canvas = true;
         }
 
+        //get node over
+        var node = this.graph.getNodeOnPos(e.canvasX,e.canvasY,this.visible_nodes);
+
         if (this.dragging_rectangle)
 		{
             this.dragging_rectangle[2] = e.canvasX - this.dragging_rectangle[0];
@@ -6328,13 +6331,10 @@ LGraphNode.prototype.executeAction = function(action)
             this.ds.offset[1] += delta[1] / this.ds.scale;
             this.dirty_canvas = true;
             this.dirty_bgcanvas = true;
-        } else if ((this.allow_interaction || (!this.allow_interaction && this.drag_mode)) && !this.read_only) {
+        } else if ((this.allow_interaction || (node && node.flags.allow_interaction)) && !this.read_only) {
             if (this.connecting_node) {
                 this.dirty_canvas = true;
             }
-
-            //get node over
-            var node = this.graph.getNodeOnPos(e.canvasX,e.canvasY,this.visible_nodes);
 
             //remove mouseover flag
             for (var i = 0, l = this.graph._nodes.length; i < l; ++i) {


### PR DESCRIPTION
The previous PR #385 was using an extra `drag_mode` flag to accomplish per node interaction override. 

This small tweak removes that requirement by getting access to the node earlier in the `processMouseMove()` function and checking the `allow_interaction` flag on the node (if available). This means that `drag_mode` isn't required for the condition check like the previous implementation.