### PR TITLE
Add ability to align selected nodes

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -12977,13 +12977,20 @@ LGraphNode.prototype.executeAction = function(action)
                     callback: LGraphCanvas.onMenuAdd
                 },
                 { content: "Add Group", callback: LGraphCanvas.onGroupAdd },
-                { content: "Align", has_submenu: true,  callback: LGraphCanvas.onGroupAlign },
 				//{ content: "Arrange", callback: that.graph.arrange },
                 //{content:"Collapse All", callback: LGraphCanvas.onMenuCollapseAll }
             ];
             /*if (LiteGraph.showCanvasOptions){
                 options.push({ content: "Options", callback: that.showShowGraphOptionsPanel });
             }*/
+
+            if (Object.keys(this.selected_nodes).length > 1) {
+                options.push({
+                    content: "Align",
+                    has_submenu: true,
+                    callback: LGraphCanvas.onGroupAlign,
+                })
+            }
 
             if (this._graph_stack && this._graph_stack.length > 0) {
                 options.push(null, {

--- a/utils/server.js
+++ b/utils/server.js
@@ -7,4 +7,4 @@ app.use('/external', express.static('external'))
 app.use('/editor', express.static('editor'))
 app.use('/', express.static('editor'))
 
-app.listen(8000, () => console.log('Example app listening on port 8000!'))
+app.listen(8000, () => console.log('Example app listening on http://127.0.0.1:8000!'))


### PR DESCRIPTION
This PR adds the ability to align selected nodes in two ways:

1. Right clicking the canvas will allow aligning nodes to the furthest node in the direction that is selected

2. Right clicking a node allows aligning all selected nodes to the node that right clicked.

(Also includes a minor change to the server.js in the example to allow easier navigation to the web interface)

Assuming this is a feature that is of interest, I have a couple specific things I'm looking for feedback on:
1. Menu order/phrasing
2. Suggestions/preference around how alignment should be calculated when aligned via canvas context menu

Short Demo:
![CleanShot 2023-04-30 at 22 53 19](https://user-images.githubusercontent.com/2661819/235416742-878e3004-d9a0-4dab-b8e5-aa82f88c3c9a.gif)
