### PR TITLE
block node dragging if node is 'pinned'

### DIFF
--- a/build/litegraph.core.js
+++ b/build/litegraph.core.js
@@ -5831,7 +5831,7 @@ LGraphNode.prototype.executeAction = function(action)
         }
 
 		//left button mouse / single finger
-        if (e.which == 1 && !this.pointer_is_double && (!node || !node.flags || !node.flags.pinned))
+        if (e.which == 1 && !this.pointer_is_double)
 		{
             if (e.ctrlKey)
 			{
@@ -6018,6 +6018,11 @@ LGraphNode.prototype.executeAction = function(action)
                 //it wasn't clicked on the links boxes
                 if (!skip_action) {
                     var block_drag_node = false;
+
+                    if(node && node.flags && node.flags.pinned) {
+						block_drag_node = true;
+					}
+
 					var pos = [e.canvasX - node.pos[0], e.canvasY - node.pos[1]];
 
                     //widgets

--- a/build/litegraph.core.js
+++ b/build/litegraph.core.js
@@ -5831,7 +5831,7 @@ LGraphNode.prototype.executeAction = function(action)
         }
 
 		//left button mouse / single finger
-        if (e.which == 1 && !this.pointer_is_double && !node.flags.pinned)
+        if (e.which == 1 && !this.pointer_is_double && (!node || !node.flags || !node.flags.pinned))
 		{
             if (e.ctrlKey)
 			{

--- a/build/litegraph.core.js
+++ b/build/litegraph.core.js
@@ -5831,7 +5831,7 @@ LGraphNode.prototype.executeAction = function(action)
         }
 
 		//left button mouse / single finger
-        if (e.which == 1 && !this.pointer_is_double)
+        if (e.which == 1 && !this.pointer_is_double && !node.flags.pinned)
 		{
             if (e.ctrlKey)
 			{


### PR DESCRIPTION
If the node is pinned,

* Block single node dragging.
* Allow other actions.
* Allow dragging of multiple selected nodes.