### PR TITLE
Fix the issue that inputs and outputs in subgraph cannot be clicked when using custom canvas size

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -5806,7 +5806,7 @@ LGraphNode.prototype.executeAction = function(action)
 		this.mouse[1] = e.clientY;
         this.graph_mouse[0] = e.canvasX;
         this.graph_mouse[1] = e.canvasY;
-		this.last_click_position = [this.mouse[0],this.mouse[1]];
+		this.last_click_position = [this.graph_mouse[0],this.graph_mouse[1]];
 	  	
 	  	if (this.pointer_is_down && is_primary ){
 		  this.pointer_is_double = true;
@@ -8100,11 +8100,10 @@ LGraphNode.prototype.executeAction = function(action)
 		bgcolor = bgcolor || LiteGraph.NODE_DEFAULT_COLOR;
 		hovercolor = hovercolor || "#555";
 		textcolor = textcolor || LiteGraph.NODE_TEXT_COLOR;
-		var yFix = y + LiteGraph.NODE_TITLE_HEIGHT + 2;	// fix the height with the title
-		var pos = this.mouse;
-		var hover = LiteGraph.isInsideRectangle( pos[0], pos[1], x,yFix,w,h );
+		var pos = this.graph_mouse;
+		var hover = LiteGraph.isInsideRectangle( pos[0], pos[1], x,y,w,h );
 		pos = this.last_click_position;
-		var clicked = pos && LiteGraph.isInsideRectangle( pos[0], pos[1], x,yFix,w,h );
+		var clicked = pos && LiteGraph.isInsideRectangle( pos[0], pos[1], x,y,w,h );
 
 		ctx.fillStyle = hover ? hovercolor : bgcolor;
 		if(clicked)


### PR DESCRIPTION
- Updated the `LGraphCanvas.prototype.processMouseDown`
- Updated the `LGraphCanvas.prototype.drawButton`

use `this.graph_mouse` instead of `this.mouse`.