### PR TITLE
Fix issue with subgraph inputs and outputs not being clickable in custom canvas size

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -8103,6 +8103,11 @@ LGraphNode.prototype.executeAction = function(action)
 		var pos = this.ds.convertOffsetToCanvas(this.graph_mouse);
 		var hover = LiteGraph.isInsideRectangle( pos[0], pos[1], x,y,w,h );
 		pos = this.last_click_position;
+        if(pos) {
+            var rect = this.canvas.getBoundingClientRect();
+            pos[0] -= rect.left;
+            pos[1] -= rect.top;
+        }
 		var clicked = pos && LiteGraph.isInsideRectangle( pos[0], pos[1], x,y,w,h );
 
 		ctx.fillStyle = hover ? hovercolor : bgcolor;

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -5806,7 +5806,7 @@ LGraphNode.prototype.executeAction = function(action)
 		this.mouse[1] = e.clientY;
         this.graph_mouse[0] = e.canvasX;
         this.graph_mouse[1] = e.canvasY;
-		this.last_click_position = [this.graph_mouse[0],this.graph_mouse[1]];
+		this.last_click_position = [this.mouse[0],this.mouse[1]];
 	  	
 	  	if (this.pointer_is_down && is_primary ){
 		  this.pointer_is_double = true;
@@ -8100,7 +8100,7 @@ LGraphNode.prototype.executeAction = function(action)
 		bgcolor = bgcolor || LiteGraph.NODE_DEFAULT_COLOR;
 		hovercolor = hovercolor || "#555";
 		textcolor = textcolor || LiteGraph.NODE_TEXT_COLOR;
-		var pos = this.graph_mouse;
+		var pos = this.ds.convertOffsetToCanvas(this.graph_mouse);
 		var hover = LiteGraph.isInsideRectangle( pos[0], pos[1], x,y,w,h );
 		pos = this.last_click_position;
 		var clicked = pos && LiteGraph.isInsideRectangle( pos[0], pos[1], x,y,w,h );

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -5806,7 +5806,7 @@ LGraphNode.prototype.executeAction = function(action)
 		this.mouse[1] = e.clientY;
         this.graph_mouse[0] = e.canvasX;
         this.graph_mouse[1] = e.canvasY;
-		this.last_click_position = [this.mouse[0],this.mouse[1]];
+		this.last_click_position = [this.graph_mouse[0],this.graph_mouse[1]];
 	  	
 	  	if (this.pointer_is_down && is_primary ){
 		  this.pointer_is_double = true;
@@ -8100,11 +8100,10 @@ LGraphNode.prototype.executeAction = function(action)
 		bgcolor = bgcolor || LiteGraph.NODE_DEFAULT_COLOR;
 		hovercolor = hovercolor || "#555";
 		textcolor = textcolor || LiteGraph.NODE_TEXT_COLOR;
-		var yFix = y + LiteGraph.NODE_TITLE_HEIGHT + 2;	// fix the height with the title
-		var pos = this.mouse;
-		var hover = LiteGraph.isInsideRectangle( pos[0], pos[1], x,yFix,w,h );
+		var pos = this.graph_mouse;
+		var hover = LiteGraph.isInsideRectangle( pos[0], pos[1], x,y,w,h );
 		pos = this.last_click_position;
-		var clicked = pos && LiteGraph.isInsideRectangle( pos[0], pos[1], x,yFix,w,h );
+		var clicked = pos && LiteGraph.isInsideRectangle( pos[0], pos[1], x,y,w,h );
 
 		ctx.fillStyle = hover ? hovercolor : bgcolor;
 		if(clicked)

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -8102,7 +8102,7 @@ LGraphNode.prototype.executeAction = function(action)
 		textcolor = textcolor || LiteGraph.NODE_TEXT_COLOR;
 		var pos = this.ds.convertOffsetToCanvas(this.graph_mouse);
 		var hover = LiteGraph.isInsideRectangle( pos[0], pos[1], x,y,w,h );
-		pos = this.last_click_position;
+		pos = this.last_click_position ? [this.last_click_position[0], this.last_click_position[1]] : null;
         if(pos) {
             var rect = this.canvas.getBoundingClientRect();
             pos[0] -= rect.left;


### PR DESCRIPTION
Fix issue with subgraph inputs and outputs not being clickable in custom canvas size

When using a custom canvas size in LiteGraph, subgraph inputs and outputs were not clickable, making it difficult to edit subgraphs. This PR fixes the issue by updating the calculation of the position and size of the subgraph inputs and outputs, so that they are correctly positioned and clickable with custom canvas sizes.

To fix this issue, the following changes were made:
- Updated the `LGraphCanvas.prototype.drawButton` method to use the `convertOffsetToCanvas` method from `DragAndScale` to convert the mouse position to the position relative to the canvas element

With these changes, the mouse position is correctly detected when clicking on rectangles, even with custom canvas sizes. This makes it easier to interact with subgraphs in LiteGraph.