### PR TITLE
Fixed exports for rollup bundler

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -14350,5 +14350,12 @@ LGraphNode.prototype.executeAction = function(action)
 
 if (typeof exports != "undefined") {
     exports.LiteGraph = this.LiteGraph;
+    exports.LGraph = this.LGraph;
+    exports.LLink = this.LLink;
+    exports.LGraphNode = this.LGraphNode;
+    exports.LGraphGroup = this.LGraphGroup;
+    exports.DragAndScale = this.DragAndScale;
+    exports.LGraphCanvas = this.LGraphCanvas;
+    exports.ContextMenu = this.ContextMenu;
 }
 


### PR DESCRIPTION
Fixed exports for rollup, first addressed here, but last time prettier got in the way and refactored all code.
https://github.com/jagenjo/litegraph.js/pull/353

This time I disabled it.