### PR TITLE
Fix auto-open bug in context menu

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -13750,7 +13750,7 @@ LGraphNode.prototype.executeAction = function(action)
         if (!disabled) {
             element.addEventListener("click", inner_onclick);
         }
-        if (options.autoopen) {
+        if (!disabled && options.autoopen) {
 			LiteGraph.pointerListenerAdd(element,"enter",inner_over);
         }
 


### PR DESCRIPTION
This bug occurred when hovering over a menu that is disabled in the context menu.