### PR TITLE
Middle mouse drag (even when over nodes)

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -6226,7 +6226,11 @@ LGraphNode.prototype.executeAction = function(action)
 						}
 					}
 				}
-			}
+			} else if (!skip_action && this.allow_dragcanvas) {
+            	//console.log("pointerevents: dragging_canvas start from middle button");
+            	this.dragging_canvas = true;
+            }
+
         	
         } else if (e.which == 3 || this.pointer_is_double) {
 			


### PR DESCRIPTION
when middle_click_slot_add_dafault_node is false.

This address two pain points I have been having.

Firstly,  A bunch of other UIs I use use middle button for dragging the area about, making me confused.
Secondly. I kept on accidentally moving nodes when I meant to move the area.
