### PR TITLE
refactor: remove '!' from server url

### DIFF
--- a/utils/server.js
+++ b/utils/server.js
@@ -7,4 +7,4 @@ app.use('/external', express.static('external'))
 app.use('/editor', express.static('editor'))
 app.use('/', express.static('editor'))
 
-app.listen(8000, () => console.log('Example app listening on http://127.0.0.1:8000!'))
+app.listen(8000, () => console.log('Example app listening on http://127.0.0.1:8000'))


### PR DESCRIPTION
hi!
im used to clicking the url and having the browser open the page.
the '!' at the end of the url ('... http://127.0.0.1:8000!') makes it not possible to click and open the browser from terminal in vscode as usual so i propose simply removing it