### PR TITLE
Fixes issue with restoring serialised graphs with widgets set to 0.

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -2530,7 +2530,7 @@
 				var w = this.widgets[i];
 				if(!w)
 					continue;
-				if(w.options && w.options.property && this.properties[ w.options.property ])
+				if(w.options && w.options.property && (this.properties[ w.options.property ] != undefined))
 					w.value = JSON.parse( JSON.stringify( this.properties[ w.options.property ] ) );
 			}
 			if (info.widgets_values) {


### PR DESCRIPTION
Fixes issue #420

Logic that checked to see if a property was set would return 'false' when the value was zero, so any numeric widget set to 0 would not be restored correctly.