### PR TITLE
Fix ignored input on HttpRequestNode

### DIFF
--- a/src/nodes/network.js
+++ b/src/nodes/network.js
@@ -381,10 +381,14 @@ HTTPRequestNode.desc = "Fetch data through HTTP";
 
 HTTPRequestNode.prototype.fetch = function()
 {
-	var url = this.properties.url;
+	var url = this.getInputData(1);
+
+    if(!url)
+        url = this.properties.url;
+    
 	if(!url)
 		return;
-
+    
 	this.boxcolor = "#FF0";
 	var that = this;
 	this._fetching = fetch(url)


### PR DESCRIPTION
Inputs on the HttpRequestNode are not being used.
This fix first tries to get an url from an input and failing that falls back to the internal url property.