### PR TITLE
Fix relative ids when copying to clipboard and skip null relative ids when pasting

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -7355,10 +7355,6 @@ LGraphNode.prototype.executeAction = function(action)
                 }
             }
 
-            if(origin_node == null) {
-                continue;
-            }
-
             var target_node = nodes[link_info[2]];
 			if( origin_node && target_node )
 	            origin_node.connect(link_info[1], target_node, link_info[3]);

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -7236,12 +7236,15 @@ LGraphNode.prototype.executeAction = function(action)
         };
         var index = 0;
         var selected_nodes_array = [];
+
+        var map = {};
+
         for (var i in this.selected_nodes) {
             var node = this.selected_nodes[i];
             if (node.clonable === false)
                 continue;
-            node._relative_id = index;
             selected_nodes_array.push(node);
+            map[node.id] = index;
             index += 1;
         }
 
@@ -7273,9 +7276,9 @@ LGraphNode.prototype.executeAction = function(action)
                         continue;
                     }
                     clipboard_info.links.push([
-                        target_node._relative_id,
+                        map[target_node.id],
                         link_info.origin_slot, //j,
-                        node._relative_id,
+                        map[node.id],
                         link_info.target_slot,
                         target_node.id
                     ]);
@@ -7341,7 +7344,7 @@ LGraphNode.prototype.executeAction = function(action)
         //create links
         for (var i = 0; i < clipboard_info.links.length; ++i) {
             var link_info = clipboard_info.links[i];
-            var origin_node;
+            var origin_node = null;
             var origin_node_relative_id = link_info[0];
             if (origin_node_relative_id != null) {
                 origin_node = nodes[origin_node_relative_id];
@@ -7351,6 +7354,11 @@ LGraphNode.prototype.executeAction = function(action)
                     origin_node = this.graph.getNodeById(origin_node_id);
                 }
             }
+
+            if(origin_node == null) {
+                continue;
+            }
+
             var target_node = nodes[link_info[2]];
 			if( origin_node && target_node )
 	            origin_node.connect(link_info[1], target_node, link_info[3]);


### PR DESCRIPTION
- When copying, the relative id is initialized but never removed, thus when making multiple copy paste, the relative ids may match with multiple nodes. I removed the relative ids and used a local map to store the relative ids.
- When pasting, the origin_node was not set to null correctly as the var scope is the entire function. As the scope is the entire function, if the relative id of the origin node is null, the origin node may had the previous value, which then creates links between nodes that never existed before.