### PR TITLE
Fix links sometimes not being correct when copy pasting nodes.

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -7341,7 +7341,7 @@ LGraphNode.prototype.executeAction = function(action)
         //create links
         for (var i = 0; i < clipboard_info.links.length; ++i) {
             var link_info = clipboard_info.links[i];
-            var origin_node;
+            var origin_node = undefined;
             var origin_node_relative_id = link_info[0];
             if (origin_node_relative_id != null) {
                 origin_node = nodes[origin_node_relative_id];


### PR DESCRIPTION
This fixes a copy paste bug where some links are sometimes pasted incorrectly when copy pasting partial graphs.