### PR TITLE
Removed duplicate length function.

### DIFF
--- a/src/nodes/base.js
+++ b/src/nodes/base.js
@@ -1361,12 +1361,6 @@ LiteGraph.registerNodeType("basic/jsonparse", JSONParse);
 
     LiteGraph.registerNodeType("basic/variable", Variable);
 
-    function length(v) {
-        if(v && v.length != null)
-			return Number(v.length);
-		return 0;
-    }
-
     LiteGraph.wrapFunctionAsNode(
         "basic/length",
         length,


### PR DESCRIPTION
This fixed an error I was getting when running 
`npm run build`
as `length() `was defined twice.